### PR TITLE
Replace alt in span with title

### DIFF
--- a/css/feedzy-rss-feeds.css
+++ b/css/feedzy-rss-feeds.css
@@ -2,7 +2,7 @@
  * feedzy-rss-feeds.css
  * Feedzy RSS Feed
  * Copyright: (c) 2016 Themeisle, themeisle.com
- * Version: 3.1.0
+ * Version: 3.1.1
  * Plugin Name: FEEDZY RSS Feeds
  * Plugin URI: http://themeisle.com/plugins/feedzy-rss-feeds/
  * Author: Themeisle

--- a/feedzy-rss-feed.php
+++ b/feedzy-rss-feed.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Feedzy RSS Feeds Lite
  * Plugin URI:        https://themeisle.com/plugins/feedzy-rss-feeds-lite/
  * Description:       This is a short description of what the plugin does. It's displayed in the WordPress admin area.
- * Version:           3.1.0
+ * Version:           3.1.1
  * Author:            Themeisle
  * Author URI:        http://themeisle.com
  * License:           GPL-2.0+

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -574,16 +574,16 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			if ( ( ! empty( $theThumbnail ) && $sc['thumb'] == 'auto' ) || $sc['thumb'] == 'yes' ) {
 				if ( ! empty( $theThumbnail ) ) {
 					$theThumbnail = $this->feedzy_image_encode( $theThumbnail );
-					$contentThumb .= '<span class="fetched" style="background-image:  url(' . $theThumbnail . ');" alt="' . $item->get_title() . '"></span>';
+					$contentThumb .= '<span class="fetched" style="background-image:  url(' . $theThumbnail . ');" title="' . $item->get_title() . '"></span>';
 				}
 				if ( $sc['thumb'] == 'yes' ) {
-					$contentThumb .= '<span class="default" style="background-image:url(' . $sc['default'] . ');" alt="' . $item->get_title() . '"></span>';
+					$contentThumb .= '<span class="default" style="background-image:url(' . $sc['default'] . ');" title="' . $item->get_title() . '"></span>';
 				}
 			}
 			$contentThumb = apply_filters( 'feedzy_thumb_output', $contentThumb, $feedURL, $sizes );
 		} else {
 			$contentThumb = '';
-			$contentThumb .= '<span class="default" style="width:' . $sizes['width'] . 'px; height:' . $sizes['height'] . 'px; background-image:url(' . $sc['default'] . ');" alt="' . $item->get_title() . '"></span>';
+			$contentThumb .= '<span class="default" style="width:' . $sizes['width'] . 'px; height:' . $sizes['height'] . 'px; background-image:url(' . $sc['default'] . ');" title="' . $item->get_title() . '"></span>';
 			$contentThumb = apply_filters( 'feedzy_thumb_output', $contentThumb, $feedURL, $sizes );
 		}
 		$contentTitle = '';

--- a/includes/feedzy-rss-feeds.php
+++ b/includes/feedzy-rss-feeds.php
@@ -104,7 +104,7 @@ class Feedzy_Rss_Feeds {
 	 */
 	public function init() {
 		self::$plugin_name = 'feedzy-rss-feeds';
-		self::$version = '3.1.0';
+		self::$version = '3.1.1';
 		self::$instance->load_dependencies();
 		self::$instance->set_locale();
 		self::$instance->define_admin_hooks();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzy-rss-feeds",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Feedzy RSS Feeds Lite",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === FEEDZY RSS Feeds Lite ===
-Contributors: themeisle,codeinwp
+Contributors: themeisle,codeinwp,hardeepasrani
 Tags: RSS, SimplePie, shortcode, feed, thumbnail, image, rss feeds, aggregator, tinyMCE, WYSIWYG, MCE, UI, flux, plugin, WordPress, widget, importer, XML, ATOM, API, parser
 Requires at least: 3.7
 Tested up to: 4.7.5

--- a/readme.txt
+++ b/readme.txt
@@ -200,6 +200,9 @@ http://docs.themeisle.com/article/636-how-to-change-author-url
 
 == Changelog ==
 
+= 3.1.1 - 22/05/2017 =
+* Fixed span alt tag, replaced with title.
+
 = 3.1.0 - 17/05/2017 =
 * Added feed categories for grouping urls.
 * Added support for feed to post feature.


### PR DESCRIPTION
Removed alt tags from span elements and replaced them with title tags. Fixes https://github.com/Codeinwp/feedzy-rss-feeds/issues/46

Also, added myself as a contributor for support purposes.