### PR TITLE
Fix author URL protocol

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -612,9 +612,9 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				}
 				if ( $authorName ) {
 					$domain      = parse_url( $newLink );
-					$authorURL   = 'http://' . $domain['host'];
+					$authorURL   = '//' . $domain['host'];
 					$authorURL   = apply_filters( 'feedzy_author_url', $authorURL, $authorName, $feedURL );
-					$contentMeta .= __( 'by', 'feedzy-rss-feeds' ) . ' <a href="http://' . $authorURL . '" target="' . $sc['target'] . '" title="' . $domain['host'] . '" >' . $authorName . '</a> ';
+					$contentMeta .= __( 'by', 'feedzy-rss-feeds' ) . ' <a href="' . $authorURL . '" target="' . $sc['target'] . '" title="' . $domain['host'] . '" >' . $authorName . '</a> ';
 				}
 			}
 			if ( $metaArgs['date'] ) {


### PR DESCRIPTION
Removed double protocol from the author URL and replaced it with //.  Fixes: https://github.com/Codeinwp/feedzy-rss-feeds/issues/48