### PR TITLE
Image with encoded URL does not get imported

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1195,6 +1195,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 		}
 
+		$the_thumbnail = html_entity_decode( $the_thumbnail, ENT_QUOTES, 'UTF-8' );
 		$the_thumbnail = apply_filters( 'feedzy_retrieve_image', $the_thumbnail, $item );
 
 		return $the_thumbnail;


### PR DESCRIPTION
https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/305