### PR TITLE
PHP warning (Illegal offset type in isset or empty) when $size is an array of integers

### DIFF
--- a/includes/feedzy-rss-feeds-feed-tweaks.php
+++ b/includes/feedzy-rss-feeds-feed-tweaks.php
@@ -61,7 +61,10 @@ function display_external_post_image( $html, $post_id, $post_thumbnail_id, $size
 	$attr['style'] = isset( $attr['style'] ) ? $attr['style'] : '';
 
 	// Get image dimensions.
-	if ( function_exists( 'wp_get_registered_image_subsizes' ) ) {
+	if (is_array($size)) {
+		$dimensions = wp_sprintf( 'width:%dpx; height:%dpx;', $size[0], $size[1] );
+		$attr['style'] .= $dimensions;	
+	} elseif ( function_exists( 'wp_get_registered_image_subsizes' ) ) {
 		$_wp_additional_image_sizes = wp_get_registered_image_subsizes();
 		if ( isset( $_wp_additional_image_sizes[ $size ] ) ) {
 			$sizes = $_wp_additional_image_sizes[ $size ];


### PR DESCRIPTION
This closes #579.
The PR introduces a check if `$size` is an array. If it is the case the problematic line will not be executed. Instead the size given in the array `$size` is used.