### PR TITLE
fix: capabilities for feedzy categories

### DIFF
--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -266,6 +266,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		$supports = array(
 			'title',
 		);
+        $capability = feedzy_current_user_can();
 		$args     = array(
 			'labels'                => $labels,
 			'supports'              => $supports,
@@ -280,6 +281,15 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			'show_in_rest'          => true,
 			'rest_base'             => 'feedzy_categories',
 			'rest_controller_class' => 'WP_REST_Posts_Controller',
+            'map_meta_cap'          => true,
+			'capabilities' => array(
+				'publish_posts'         => $capability,
+				'edit_posts'            => $capability,
+				'edit_others_posts'     => $capability,
+				'delete_posts'          => $capability,
+				'delete_others_posts'   => $capability,
+				'read_private_posts'    => $capability,
+			),
 		);
 		$args     = apply_filters( 'feedzy_post_type_args', $args );
 		register_post_type( 'feedzy_categories', $args );

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -266,7 +266,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		$supports = array(
 			'title',
 		);
-        $capability = feedzy_current_user_can();
+		$capability = feedzy_current_user_can();
 		$args     = array(
 			'labels'                => $labels,
 			'supports'              => $supports,
@@ -281,7 +281,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			'show_in_rest'          => true,
 			'rest_base'             => 'feedzy_categories',
 			'rest_controller_class' => 'WP_REST_Posts_Controller',
-            'map_meta_cap'          => true,
+			'map_meta_cap'          => true,
 			'capabilities' => array(
 				'publish_posts'         => $capability,
 				'edit_posts'            => $capability,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="unit-tests">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/tests/test-post-access.php
+++ b/tests/test-post-access.php
@@ -27,7 +27,7 @@ class Test_Post_Access extends WP_UnitTestCase {
 		return $result;
 	}
 
-	public function test_post_access() {
+	public function test_custom_post_access() {
 		$random_name = $this->get_rand_name();
 		$admin_id     = $this->factory->user->create(
 			array(

--- a/tests/test-post-access.php
+++ b/tests/test-post-access.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     feedzy-rss-feeds-pro
+ * @subpackage  Tests
+ * @copyright   Copyright (c) 2017, Bogdan Preda
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       1.2.0
+ */
+class Test_Post_Access extends WP_UnitTestCase {
+
+	/**
+	 * Utility method to generate a random 5 char string.
+	 *
+	 * @since   3.0.12
+	 * @access  private
+	 * @return string
+	 */
+	private function get_rand_name() {
+		$characters = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+		$result     = '';
+		for ( $i = 0; $i < 5; $i ++ ) {
+			$result .= $characters[ mt_rand( 0, 61 ) ];
+		}
+
+		return $result;
+	}
+
+	public function test_post_access() {
+		$random_name = $this->get_rand_name();
+		$admin_id     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+		$p = $this->factory->post->create_and_get(
+			array(
+				'post_title'  => $random_name,
+				'post_type'   => 'feedzy_categories',
+				'post_author' => $admin_id,
+			)
+		);
+		do_action( 'save_post', $p->ID, $p );
+		$this->assertEquals( $p->post_title, $random_name );
+		$this->assertEquals( $p->post_type, 'feedzy_categories' );
+
+		$this->assertTrue( feedzy_current_user_can() );
+		$this->assertTrue( current_user_can( 'edit_post', $p->ID ) );
+
+
+		$contributor_id = $this->factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+		wp_set_current_user( $contributor_id );
+
+		$this->assertFalse( feedzy_current_user_can() );
+		$this->assertFalse( current_user_can( 'edit_post', $p->ID ) );
+
+	}
+
+}


### PR DESCRIPTION
### Summary
Changed capabilities for accesing custom post type to match with the menu availability.
Added unit test for this.

### How to test
1. Create multiple accounts with different roles. ( Administrator, Contributor, Editor)
2. Check that only the Administrator can access the custom feedzy categories

Closes: Codeinwp/feedzy-rss-feeds-pro#674