### PR TITLE
Add NPS survey

### DIFF
--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -129,9 +129,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		if ( 'feedzy_imports' === $screen->post_type && 'edit' === $screen->base ) {
-			if ( ! defined( 'CYPRESS_TESTING' ) ) {
-				$this->register_survey();
-			}
+			$this->register_survey();
 		}
 
 		if ( 'feedzy_categories' === $screen->post_type ) {
@@ -159,9 +157,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 				)
 			);
 
-			if ( ! defined( 'CYPRESS_TESTING' ) ) {
-				$this->register_survey();
-			}
+			$this->register_survey();
 		}
 
 		if ( 'feedzy_page_feedzy-settings' === $screen->base ) {
@@ -182,9 +178,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 				)
 			);
 
-			if ( ! defined( 'CYPRESS_TESTING' ) ) {
-				$this->register_survey();
-			}
+			$this->register_survey();
 		}
 
 		$upsell_screens = array( 'feedzy-rss_page_feedzy-settings', 'feedzy-rss_page_feedzy-admin-menu-pro-upsell' );
@@ -210,9 +204,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			);
 			wp_enqueue_style( 'wp-block-editor' );
 
-			if ( ! defined( 'CYPRESS_TESTING' ) ) {
-				$this->register_survey();
-			}
+			$this->register_survey();
 		}
 		if ( ! defined( 'TI_CYPRESS_TESTING' ) && ( 'edit' !== $screen->base && 'feedzy_imports' === $screen->post_type && feedzy_show_import_tour() ) ) {
 			wp_enqueue_script( $this->plugin_name . '_on_boarding', FEEDZY_ABSURL . 'js/Onboarding/import-onboarding.min.js', array( 'react', 'react-dom', 'wp-editor', 'wp-api', 'lodash' ), $this->version, true );
@@ -223,9 +215,9 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		if ( 'feedzy_page_feedzy-support' === $screen->base || ( 'edit' !== $screen->base && 'feedzy_imports' === $screen->post_type ) ) {
-			if ( ! defined( 'CYPRESS_TESTING' ) ) {
-				$this->register_survey();
-			}
+
+			$this->register_survey();
+
 			wp_enqueue_script( $this->plugin_name . '_feedback', FEEDZY_ABSURL . 'js/FeedBack/feedback.min.js', array( 'react', 'react-dom', 'wp-editor', 'wp-api', 'lodash' ), $this->version, true );
 			wp_enqueue_style( 'wp-block-editor' );
 
@@ -1696,8 +1688,16 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 
 	/**
 	 * Register the survey script.
+	 *
+	 * It does register if we are in CI environment.
+	 *
+	 * @return void
 	 */
 	public function register_survey() {
+
+		if ( defined( 'CYPRESS_TESTING' ) ) {
+			return;
+		}
 
 		// Register the survey script.
 		wp_register_script( $this->plugin_name . '_survey_formbrick', 'https://unpkg.com/@formbricks/js@^1.5.1/dist/index.umd.js', array(), $this->version, true );

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1699,9 +1699,13 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			return;
 		}
 
-		// Register the survey script.
-		wp_register_script( $this->plugin_name . '_survey_formbrick', 'https://unpkg.com/@formbricks/js@^1.5.1/dist/index.umd.js', array(), $this->version, true );
-		wp_enqueue_script( $this->plugin_name . '_survey', FEEDZY_ABSURL . 'js/survey.js', array( $this->plugin_name . '_survey_formbrick' ), $this->version, true );
+		$survey_handler = apply_filters( 'themeisle_sdk_dependency_script_handler', 'survey' );
+		if ( empty( $survey_handler ) ) {
+			return;
+		}
+
+		do_action( 'themeisle_sdk_dependency_enqueue_script', 'survey' );
+		wp_enqueue_script( $this->plugin_name . '_survey', FEEDZY_ABSURL . 'js/survey.js', array( $survey_handler ), $this->version, true );
 		wp_localize_script( $this->plugin_name . '_survey', 'feedzySurveyData', $this->get_survery_metadata() );
 	}
 }

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1627,7 +1627,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		$plan = (int) $license_data->plan;
-		$current_category = 0;
+		$current_category = -1;
 
 		$categories = array(
 			'1' => array(1, 4, 9), // Personal

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1628,7 +1628,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		if ( ! empty( $license->key ) ) {
 			$user_id .= $license->key;
 		} else {
-			$user_id .= 'free';
+			$user_id .= preg_replace( '/[^\w\d]*/', '', get_site_url() ); // Use a normalized version of the site URL as a user ID for free users.
 		}
 
 		$integration_status = $this->api_license_status();

--- a/js/survey.js
+++ b/js/survey.js
@@ -3,8 +3,8 @@
  * 
  * @see https://github.com/formbricks/setup-examples/tree/main/html
  */
-window.addEventListener('load', function () {
-    window?.formbricks?.init?.({
+window.addEventListener('themeisle:survey:loaded', function () {
+    window?.tsdk_formbricks?.init?.({
         environmentId: "clskgehf78eu5podwdrnzciti",
         apiHost: "https://app.formbricks.com",
         ...(window?.feedzySurveyData ?? {}),

--- a/js/survey.js
+++ b/js/survey.js
@@ -1,0 +1,13 @@
+/**
+ * Initialize the formbricks survey.
+ * 
+ * @see https://github.com/formbricks/setup-examples/tree/main/html
+ */
+window.addEventListener('load', function () {
+    window?.formbricks?.init?.({
+        environmentId: "clskgehf78eu5podwdrnzciti",
+        apiHost: "https://app.formbricks.com",
+        debug: true,
+        ...(window?.feedzySurveyData ?? {})
+    });
+});    

--- a/js/survey.js
+++ b/js/survey.js
@@ -7,7 +7,6 @@ window.addEventListener('load', function () {
     window?.formbricks?.init?.({
         environmentId: "clskgehf78eu5podwdrnzciti",
         apiHost: "https://app.formbricks.com",
-        debug: true,
-        ...(window?.feedzySurveyData ?? {})
+        ...(window?.feedzySurveyData ?? {}),
     });
 });    


### PR DESCRIPTION
## Summary

- Add code to initiate NPS survey with Formbricks. 
- Collect attribute data
- Hook to settings pages except the About Us page.

Similar implementation also in:
- https://github.com/Codeinwp/multi-pages-plugin/pull/330
- https://github.com/Codeinwp/hestia-pro/pull/2617

## Testing

- Check if your NPS survey shows up. (On a new session, it shows after 5 seconds)

> [!NOTE]
> If you want to re-trigger the survey, you will need to follow the same steps as here: https://github.com/Codeinwp/neve/pull/4186#issuecomment-1906364169
