### PR TITLE
Re-allow users to add magic tags to featured image

### DIFF
--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -265,7 +265,7 @@
 		$( '.feedzy-keyword-filter, #feedzy-import-source' ).on('keyup keypress', function(e) {
 			var keyCode = e.keyCode || e.which;
 			var addTagBtn = $( this ).parents( '.fz-input-icon' ).find( '.add-outside-tags' );
-			
+
 			if ( '' === $( this ).val() ) {
 				addTagBtn.attr( 'disabled', true );
 			} else if ( addTagBtn.hasClass( 'fz-plus-btn' ) ) {
@@ -481,8 +481,8 @@
 		// Tagify for normal mix content field.
 		$( '.fz-tagify-image' ).tagify( {
 			mode: 'mix',
-			editTags: false,
-			userInput: false,
+			editTags: true,
+			userInput: true,
 			addTagOn: [],
 			templates: {
 				tag: function(tagData) {
@@ -836,4 +836,4 @@
 			$( '.feedzy-open-media' ).html( feedzy.i10n.action_btn_text_1 );
 		});
 	}
-})(jQuery, feedzy);
+}(jQuery, feedzy));


### PR DESCRIPTION
## Changes

Allow the user to add and edit their own custom tags.

## Screenshots

### Feed Setting
![image](https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/854ec2a3-3204-4905-b91c-d7696bb26419)

### Imported Post
![image](https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/2ac2b3a1-a4d8-499e-b88b-d9efdcd8f6d6)


## Testing

Use a RSS feed that has images in a different tag other than `image`. You can the one from NASA: https://photojournal.jpl.nasa.gov/rss/index.html

The syntax from the custom is `[#item_custom_<xml_tag>@<xml_attribute>]`. ( In the case of the one from NASA, the `xml_attributes` is `hiresJpeg` without any attribute )

1. Create a new feed import
2. Add a feed that has images
3. In the Map Content, on Featured Images, add a custom tag that extracts the image.
4. Check if they are imported.

> [!NOTE]
> Ensure images from the feed can be accessed; otherwise, you will get an importing error. Choose a good feed source.

