### PR TITLE
fix: prevent jobs from stopping the cron loop

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1187,13 +1187,20 @@ class Feedzy_Rss_Feeds_Import {
 			'post_status' => 'publish',
 			'numberposts' => 99,
 		);
+
 		$feedzy_imports = get_posts( $args );
 		foreach ( $feedzy_imports as $job ) {
-			$result = $this->run_job( $job, $max );
-			if ( empty( $result ) ) {
-				$this->run_job( $job, $max );
+			try {
+				$result = $this->run_job( $job, $max );
+				if ( empty( $result ) ) {
+					$this->run_job( $job, $max );
+				}
+				do_action( 'feedzy_run_cron_extra', $job );
+			} catch ( Exception $e ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					error_log( '[Feedzy Run Cron][Post title: ' . ( ! empty( $job->post_title ) ? $job->post_title : '' ) . '] Error: ' . $e->getMessage() );
+				}
 			}
-			do_action( 'feedzy_run_cron_extra', $job );
 		}
 	}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1782,7 +1782,7 @@ class Feedzy_Rss_Feeds_Import {
 				}
 
 				// Fetch image from graby.
-				if ( empty( $image_url ) && ( wp_doing_cron() || defined( 'FEEDZY_PRO_FETCH_ITEM_IMG_URL' ) ) ) {
+				if ( empty( $image_url ) && ( wp_doing_cron() && defined( 'FEEDZY_PRO_FETCH_ITEM_IMG_URL' ) ) ) {
 					// if license does not exist, use the site url
 					// this should obviously never happen unless on dev instances.
 					$license = apply_filters( 'product_feedzy_license_key', sprintf( 'n/a - %s', get_site_url() ) );


### PR DESCRIPTION
## Summary

- Fixed a condition for a Pro feature that crashed the cron for free users. The bug was introduced in https://github.com/Codeinwp/feedzy-rss-feeds/commit/1a73ce68222d8efadfd9a97813e68949e61f7c72 for this issue https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/504
- Added a `try...catch` mechanism to stop possible errors from propagating inside the loop of the cron event.

 ## Testing

> [!NOTE]
> This bug affected Free users; do not **install** the Pro version.

- Use links from this comment: https://github.com/Codeinwp/feedzy-rss-feeds/issues/883#issuecomment-1974173592
- Enable the debug and debug logs.
- Install the plugin that can run the cron job, like https://wordpress.org/plugins/advanced-cron-manager/
- Run the cron named `feedzy_job`.
- Check the logs if you see some errors with the prefix: `[Feedzy Run Cron]` or fatal crash regarding `'FEEDZY_PRO_FETCH_ITEM_IMG_URL'`

![image](https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/9b8dde84-00eb-402d-8d31-7f4a871d7d28)
