### PR TITLE
fix: css name conflict for `.right` class name

### DIFF
--- a/css/metabox-settings.css
+++ b/css/metabox-settings.css
@@ -42,16 +42,16 @@
 	.fz-input-group{flex-wrap: wrap;}
 	.fz-input-group .fz-input-group-right{width: 100%; padding-left: 0; padding-top: 8px;}
 	.fz-input-group .fz-input-group-right .btn.dropdown-toggle{width: 100%;}
-	.fz-form-wrap .form-block.form-block-two-column .left{width: 100%; padding-right: 0; padding-bottom: 24px;}
-	.fz-form-wrap .form-block.form-block-two-column .right{width: 100%;}
-	.fz-form-action .left{width: 100%; padding-bottom: 16px;}
-	.fz-form-action .left .btn{width: 100%; display: block; text-align: center;}
-	.fz-form-action .right{width: 100%; flex-direction: column;}
-	.fz-form-action .right .btn + .btn{margin-left: 0; margin-top: 8px;}
+	.fz-form-wrap .form-block.form-block-two-column .fz-left{width: 100%; padding-right: 0; padding-bottom: 24px;}
+	.fz-form-wrap .form-block.form-block-two-column .fz-right{width: 100%;}
+	.fz-form-action .fz-left{width: 100%; padding-bottom: 16px;}
+	.fz-form-action .fz-left .btn{width: 100%; display: block; text-align: center;}
+	.fz-form-action .fz-right{width: 100%; flex-direction: column;}
+	.fz-form-action .fz-right .btn + .btn{margin-left: 0; margin-top: 8px;}
 	.fz-form-row .fz-form-col-6, .fz-form-row .fz-form-col-4, .fz-form-row .fz-form-col-8{width: 100%;}
 	.fz-document-list > ul > li{width: 100%;}
-	.fz-help-improve-box .left{width: 100%;}
-	.fz-help-improve-box .right{width: 100%;}
+	.fz-help-improve-box .fz-left{width: 100%;}
+	.fz-help-improve-box .fz-right{width: 100%;}
 	.fz-tabs-menu ul {flex-wrap: wrap;}
 	.fz-tabs-menu ul li{flex-shrink: 0; width: 50%;}
 	.fz-tabs-menu ul li a{padding: 0px; border: 1px solid transparent;}

--- a/css/settings.css
+++ b/css/settings.css
@@ -350,14 +350,15 @@ fieldset[disabled] .form-control {
 	display: flex;
 	flex-wrap: wrap;
 }
-.fz-form-wrap .form-block.form-block-two-column .left{
+.fz-form-wrap .form-block.form-block-two-column .fz-left{
 	width: 285px;
 	padding-right: 24px;
 }
-.fz-form-wrap .form-block.form-block-two-column .right{
+.fz-form-wrap .form-block.form-block-two-column .fz-right{
 	width: calc(100% - 285px);
+	text-align: left;
 }
-.fz-form-wrap .form-block.form-block-two-column .right .upgrade-alert{
+.fz-form-wrap .form-block.form-block-two-column .fz-right .upgrade-alert{
 	margin-top: 20px;
 }
 .fz-form-wrap .form-block .only-pro-content{
@@ -666,14 +667,14 @@ input.fz-switch-toggle[type=checkbox]:checked:before{
 	flex-wrap: wrap;
 	justify-content: space-between;
 }
-.fz-form-action .right{
+.fz-form-action .fz-right{
 	display: flex;
 	flex-wrap: wrap;
 }
-.fz-form-action .right .btn{
+.fz-form-action .fz-right .btn{
 	margin-bottom: 8px;
 }
-.fz-form-action .right .btn + .btn{
+.fz-form-action .fz-right .btn + .btn{
 	margin-left: 16px;
 }
 
@@ -1310,18 +1311,18 @@ input.fz-switch-toggle[type=checkbox]:checked:before{
 	flex-direction: row-reverse;
 	border: 1px solid #D9D9D9;
 }
-.fz-help-improve-box .left{
+.fz-help-improve-box .fz-left{
 	width: calc(100% - 320px);
 	padding: 30px;
 }
-.fz-help-improve-box .left p{
+.fz-help-improve-box .fz-left p{
 	font-size: 16px;
 	line-height: 24px;
 	color: #050505;
 	margin-bottom: 24px;
 	max-width: 710px;
 }
-.fz-help-improve-box .right{
+.fz-help-improve-box .fz-right{
 	width: 320px;
 	padding: 18px;
 	background-color: #F5F7F9;

--- a/includes/layouts/feedzy-improve.php
+++ b/includes/layouts/feedzy-improve.php
@@ -1,10 +1,10 @@
 <div id="fz-feedback-modal"></div>
 <div class="fz-help-improve-wrap">
 	<div class="fz-help-improve-box">
-		<div class="right">
+		<div class="fz-right">
 			<img src="<?php echo esc_url( FEEDZY_ABSURL . 'img/improve-feedzy.png' ); ?>" alt="">
 		</div>
-		<div class="left">
+		<div class="fz-left">
 			<h3 class="h3 pb-16">Answer a few questions to help us improve Feedzy</h3>
 			<p>We're always looking for suggestions to further improve Feedzy.
 			<?php if ( ! feedzy_is_pro() ) { ?>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -126,7 +126,7 @@ global $post;
 				<div class="fz-form-wrap">
 					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'filter-keyword', 'import' ) ); ?>
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Filter by Keyword(s)', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 							<div class="form-block-pro-text">
 								<?php
@@ -140,7 +140,7 @@ global $post;
 								<a href="https://docs.themeisle.com/article/1154-how-to-use-feed-to-post-feature-in-feedzy#filters" target="_blank"><?php esc_html_e( 'Learn More', 'feedzy-rss-feeds' ); ?></a>
 							</div>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="fz-form-group">
 								<label class="form-label"><?php esc_html_e( 'Display item only if the selected field contains specific keyword(s)', 'feedzy-rss-feeds' ); ?></label>
 								<div class="fz-input-group">
@@ -180,10 +180,10 @@ global $post;
 
 					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'exclude-items', 'import' ) ); ?>
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Exclude Items', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="fz-form-group">
 								<label class="form-label"><?php esc_html_e( 'Exclude item if the selected field contains specific keyword(s)', 'feedzy-rss-feeds' ); ?></label>
 								<div class="fz-input-group">
@@ -223,10 +223,10 @@ global $post;
 
 					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'filter-time-range', 'import' ) ); ?>
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Filter by Time Range', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="date-range-group">
 								<div class="fz-form-group">
 									<label class="form-label"
@@ -286,10 +286,10 @@ global $post;
 					<div class="fz-tab-content" id="fz-general">
 						<div class="fz-form-wrap">
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Type', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The post type you want to use for the generated post.', 'feedzy-rss-feeds' ); ?></label>
 										<div class="mx-320">
@@ -310,10 +310,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Taxonomy', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'Assigns the post to a Category', 'feedzy-rss-feeds' ); ?></label>
 										<div class="mx-320">
@@ -342,10 +342,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Status', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The post status for the imported posts.', 'feedzy-rss-feeds' ); ?></label>
 										<div class="mx-320">
@@ -370,10 +370,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Title', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The title for the generated post.', 'feedzy-rss-feeds' ); ?></label>
 										<div class="fz-input-group">
@@ -405,10 +405,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Date', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The date for the generated post. ', 'feedzy-rss-feeds' ); ?></label>
 										<div class="fz-input-group">
@@ -441,10 +441,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Content', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The content for the generated post', 'feedzy-rss-feeds' ); ?></label>
 										<div class="fz-input-group">
@@ -484,10 +484,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Featured image', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The Featured image for the generated post.', 'feedzy-rss-feeds' ); ?></label>
 										<div class="fz-input-group">
@@ -523,10 +523,10 @@ global $post;
 					<div class="fz-tab-content" id="fz-advanced-options">
 						<div class="fz-form-wrap">
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'External image', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<div class="fz-form-switch">
 											<input id="use-external-image" name="feedzy_meta_data[import_use_external_image]"
@@ -543,10 +543,10 @@ global $post;
 
 							<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 								<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'post-author', 'import' ) ); ?>
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Author', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<div class="fz-form-switch">
 											<input id="feedzy-toggle_author_admin" name="feedzy_meta_data[import_link_author_admin]"
@@ -578,10 +578,10 @@ global $post;
 							</div>
 
 							<div class="form-block form-block-two-column">
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Post Excerpt', 'feedzy-rss-feeds' ); ?></h4>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'The Post Excerpt for the generated post', 'feedzy-rss-feeds' ); ?></label>
 										<div class="fz-input-group">
@@ -622,14 +622,14 @@ global $post;
 
 							<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 								<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'custom-fields', 'import' ) ); ?>
-								<div class="left">
+								<div class="fz-left">
 									<h4 class="h4"><?php esc_html_e( 'Custom Fields', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 									<div class="form-block-pro-text">
 									<?php esc_html_e( 'This feature is only for Pro users.', 'feedzy-rss-feeds' ); ?><br>
 										<a href="https://docs.themeisle.com/article/977-how-do-i-extract-values-from-custom-tags-in-feedzy" target="_blank"><?php esc_html_e( 'Learn More', 'feedzy-rss-feeds' ); ?></a>
 									</div>
 								</div>
-								<div class="right">
+								<div class="fz-right">
 									<div class="fz-form-group">
 										<label class="form-label pb-16"><?php esc_html_e( 'Customizable fields to fetch custom values such as date updated, rating, etc.', 'feedzy-rss-feeds' ); ?></label>
 										<div class="custom_fields">
@@ -690,10 +690,10 @@ global $post;
 				<div class="fz-form-wrap">
 					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'auto-delete', 'import' ) ); ?>
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Auto-Delete', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="fz-form-group">
 								<label class="form-label"><?php esc_html_e( 'Delete the posts created for this import after a number of days', 'feedzy-rss-feeds' ); ?></label>
 								<input type="number" min="0" max="9999" id="feedzy_delete_days" name="feedzy_meta_data[import_feed_delete_days]" class="form-control" value="<?php echo esc_attr( (int) $import_feed_delete_days ); ?>" />
@@ -705,10 +705,10 @@ global $post;
 					</div>
 
 					<div class="form-block form-block-two-column">
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Remove Duplicates', 'feedzy-rss-feeds' ); ?></h4>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="fz-form-group">
 								<div class="fz-form-switch">
 									<input id="remove-duplicates" name="feedzy_meta_data[import_remove_duplicates]"
@@ -725,10 +725,10 @@ global $post;
 					</div>
 
 					<div class="form-block form-block-two-column">
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Items Count', 'feedzy-rss-feeds' ); ?></h4>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="fz-form-group">
 								<label class="form-label"><?php esc_html_e( 'How many feed items to import from the source?', 'feedzy-rss-feeds' ); ?></label>
 								<input type="number" min="0" max="9999" id="feedzy_item_limit" name="feedzy_meta_data[import_feed_limit]" class="form-control" value="<?php echo esc_attr( (int) $import_feed_limit ); ?>" />
@@ -740,10 +740,10 @@ global $post;
 					</div>
 					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-imaget', 'import' ) ); ?>
-						<div class="left">
+						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Fallback Image', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 						</div>
-						<div class="right">
+						<div class="fz-right">
 							<div class="fz-form-group">
 								<label class="form-label"><?php esc_html_e( 'Select an image to be the fallback featured image.', 'feedzy-rss-feeds' ); ?></label>
 								<?php
@@ -768,7 +768,7 @@ global $post;
 					</div>
 					<?php if ( function_exists( 'icl_get_languages' ) ) : ?>
 						<div class="form-block form-block-two-column">
-							<div class="left">
+							<div class="fz-left">
 								<h4 class="h4"><?php esc_html_e( 'Assign Language', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 								<?php if ( ! feedzy_is_pro() ) : ?>
 									<div class="form-block-pro-text">
@@ -777,7 +777,7 @@ global $post;
 									</div>
 								<?php endif; ?>
 							</div>
-							<div class="right">
+							<div class="fz-right">
 								<div class="fz-form-group">
 									<label class="form-label"><?php esc_html_e( 'Content Language after import', 'feedzy-rss-feeds' ); ?></label>
 									<div class="mx-320">
@@ -1020,13 +1020,13 @@ global $post;
 						$target_lang = apply_filters( 'feedzy_available_automatically_translation_language', $target_lang );
 						?>
 						<div class="form-block form-block-two-column">
-							<div class="left">
+							<div class="fz-left">
 								<h4 class="h4"><?php esc_html_e( 'Enable automatic translation?', 'feedzy-rss-feeds' ); ?></h4>
 									<div class="form-block-pro-text">
 										<?php esc_html_e( 'Enable and select the language to translate the text automatically. Enable this only if you used the Translate magic tags. The default is English', 'feedzy-rss-feeds' ); ?>
 									</div>
 							</div>
-							<div class="right">
+							<div class="fz-right">
 								<div class="fz-form-group">
 									<div style="margin-bottom: 5px;">
 										<input id="feedzy-auto-translation" name="feedzy_meta_data[import_auto_translation]" class="fz-switch-toggle" type="checkbox" value="yes" <?php echo esc_attr( $import_auto_translation ); ?>>
@@ -1056,7 +1056,7 @@ global $post;
 
 	<input type="hidden" id="custom_post_status" name="custom_post_status" value="draft" />
 	<div class="fz-form-action">
-		<div class="left">
+		<div class="fz-left">
 			<?php
 				$clone_url = wp_nonce_url(
 					add_query_arg(
@@ -1072,7 +1072,7 @@ global $post;
 				?>
 			<a href="<?php echo esc_url( $clone_url ); ?>" class="btn btn-ghost"><?php esc_html_e( 'Clone Import', 'feedzy-rss-feeds' ); ?></a>
 		</div>
-		<div class="right">
+		<div class="fz-right">
 			<button type="button" id="preflight" name="check" class="btn btn-ghost" value="Check"
 			title="<?php esc_html_e( 'Click to see what items will be imported from the source, according to the filters specified', 'feedzy-rss-feeds' ); ?>"><?php esc_html_e( 'Preview  Import', 'feedzy-rss-feeds' ); ?></button>
 			<?php


### PR DESCRIPTION
Closes #901 

## Summary

- Appended to `.right` and `.left` the product suffix `fz-` to avoid conflict with other plugins CSS over generic names.
- Enforced the `text-align: left`.

## Screenshot

![image](https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/e4b5f501-5bf5-402e-8fd4-2412a2a1628a)

## Testing

1. Install Genesis Block plugin: https://wordpress.org/plugins/genesis-blocks/
2. Create a new feed
3. The layout should be like before.