### PR TITLE
fix: allow mix content in title field for map content

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -902,9 +902,9 @@ input.fz-switch-toggle[type=checkbox]:checked:before{
 }
 .fz-form-wrap .tagify__tag{
 	position: relative;
-	margin-left: 0;
-	margin-right: 16px;
-	margin-bottom: 16px;
+	margin-left: 2px;
+	margin-right: 2px;
+	margin-bottom: 2px;
 	vertical-align: top;
 }
 .fz-form-wrap .tagify__tag>div{

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1417,7 +1417,7 @@ class Feedzy_Rss_Feeds_Import {
 			$item_date = $item['item_date_formatted'];
 
 			// Transform any structure like [[{"value":"[#item_title]"}]] to [#item_title].
-			$import_title = preg_replace('/\[\[\{"value":"(\[#[^]]+\])"\}\]\]/', '$1', $import_title);
+			$import_title = preg_replace( '/\[\[\{"value":"(\[#[^]]+\])"\}\]\]/', '$1', $import_title );
 
 			// Get translated item title.
 			$translated_title = '';

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1416,6 +1416,9 @@ class Feedzy_Rss_Feeds_Import {
 			$item_date = date( get_option( 'date_format' ) . ' at ' . get_option( 'time_format' ), $item['item_date'] );
 			$item_date = $item['item_date_formatted'];
 
+			// Transform any structure like [[{"value":"[#item_title]"}]] to [#item_title].
+			$import_title = preg_replace('/\[\[\{"value":"(\[#[^]]+\])"\}\]\]/', '$1', $import_title);
+
 			// Get translated item title.
 			$translated_title = '';
 			if ( $import_auto_translation && ( false !== strpos( $import_title, '[#translated_title]' ) || false !== strpos( $post_excerpt, '[#translated_title]' ) ) ) {

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -468,7 +468,7 @@
 		} );
 
 		// Tagify for normal textbox.
-		$( '.fz-input-tagify:not(.fz-tagify-image)' ).tagify( {
+		$( '.fz-input-tagify:not(.fz-tagify-image):not([name="feedzy_meta_data[import_post_title]"])' ).tagify( {
 			editTags: false,
 			originalInputValueFormat: function( valuesArr ) {
 				return valuesArr.map( function( item ) {
@@ -476,6 +476,11 @@
 				} )
 				.join( ', ' );
 			}
+		} );
+
+		// Tagify the title field.
+		$( '.fz-input-tagify[name="feedzy_meta_data[import_post_title]"]:not(.fz-tagify-image)' ).tagify( {
+			mode: 'mix'
 		} );
 
 		// Tagify for normal mix content field.


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Allow mix content in the Title field on Map Content.

Changes:
- reducing the margin for the tags to allow better alignment with simple content
- made a special case for the title field tagify initialization
- before the mix content, the tags are saved as a list and transformed from `[[{"value":"[#item_title]"}], [{"value":"[#item_date]"}]]` to `[#item_title], [#item_date]`. With mix content enabled, the data is saved like this: `Title "[[{"value":"[#item_title]"}]]" on [[{"value":"[#item_date]"}]]`; a clean is done with regex to get `Title "[#item_title]" on [#item_date]`

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/5745da03-6201-442b-a21b-a315a05872bd

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a new import
- In the Title Post field on Map Content, try to add a combination of text and tags ( do no use closing with `<>` as it will be filtered by the HTML filter )
- Run the imported and check the title.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step f#904 r you)

<!-- Issues that this pull request closes. -->
Closes #904 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
