### PR TITLE
Fix/mime content type

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2038,6 +2038,7 @@ class Feedzy_Rss_Feeds_Import {
 				return false;
 			}
 
+			$type = '';
 			// try first to get the file type using the built-in function if available.
 			if ( function_exists( 'mime_content_type' ) ) {
 				$type = mime_content_type( $local_file );

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2038,10 +2038,16 @@ class Feedzy_Rss_Feeds_Import {
 				return false;
 			}
 
-			$type = $this->get_file_type_by_url( $img_source_url );
-			if ( empty( $type ) && function_exists( 'mime_content_type' ) ) {
+			// try first to get the file type using the built-in function if available.
+			if ( function_exists( 'mime_content_type' ) ) {
 				$type = mime_content_type( $local_file );
 			}
+
+			// if the file type is not found, try to get it from the URL.
+			if ( empty( $type ) ) {
+				$type = $this->get_file_type_by_url( $img_source_url );
+			}
+
 			// the file is downloaded with a .tmp extension
 			// if the URL mentions the extension of the file, the upload succeeds
 			// but if the URL is like https://source.unsplash.com/random, then the upload fails

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1978,23 +1978,23 @@ class Feedzy_Rss_Feeds_Import {
 	}
 
 	/**
-     * Will retireve the file type of a file by its URL.
-     *
+	 * Will retireve the file type of a file by its URL.
+	 *
 	 * @param string $url The URL of the file.
 	 *
 	 * @return string
 	 */
-    private function get_file_type_by_url( $url ) {
-        $response  = wp_remote_get( $url );
+	private function get_file_type_by_url( $url ) {
+		$response  = wp_remote_get( $url );
 
-        // wp_remote_retrieve_header can return an array if there are multiple headers with the same name
-        $content_type = wp_remote_retrieve_header( $response, 'content-type' );
-        if ( is_array( $content_type ) ) {
-            $content_type = $content_type[0];
-        }
+		// wp_remote_retrieve_header can return an array if there are multiple headers with the same name
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( is_array( $content_type ) ) {
+			$content_type = $content_type[0];
+		}
 
-        return $content_type;
-    }
+		return $content_type;
+	}
 
 	/**
 	 * Downloads and sets a post featured image if possible.
@@ -2038,10 +2038,10 @@ class Feedzy_Rss_Feeds_Import {
 				return false;
 			}
 
-            $type = $this->get_file_type_by_url( $img_source_url );
-            if ( empty( $type ) && function_exists( 'mime_content_type' ) ) {
-	            $type = mime_content_type( $local_file );
-            }
+			$type = $this->get_file_type_by_url( $img_source_url );
+			if ( empty( $type ) && function_exists( 'mime_content_type' ) ) {
+				$type = mime_content_type( $local_file );
+			}
 			// the file is downloaded with a .tmp extension
 			// if the URL mentions the extension of the file, the upload succeeds
 			// but if the URL is like https://source.unsplash.com/random, then the upload fails

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1978,6 +1978,25 @@ class Feedzy_Rss_Feeds_Import {
 	}
 
 	/**
+     * Will retireve the file type of a file by its URL.
+     *
+	 * @param string $url The URL of the file.
+	 *
+	 * @return string
+	 */
+    private function get_file_type_by_url( $url ) {
+        $response  = wp_remote_get( $url );
+
+        // wp_remote_retrieve_header can return an array if there are multiple headers with the same name
+        $content_type = wp_remote_retrieve_header( $response, 'content-type' );
+        if ( is_array( $content_type ) ) {
+            $content_type = $content_type[0];
+        }
+
+        return $content_type;
+    }
+
+	/**
 	 * Downloads and sets a post featured image if possible.
 	 *
 	 * @param string  $img_source_url The download source URL for the image.
@@ -2019,7 +2038,10 @@ class Feedzy_Rss_Feeds_Import {
 				return false;
 			}
 
-			$type = mime_content_type( $local_file );
+            $type = $this->get_file_type_by_url( $img_source_url );
+            if ( empty( $type ) && function_exists( 'mime_content_type' ) ) {
+	            $type = mime_content_type( $local_file );
+            }
 			// the file is downloaded with a .tmp extension
 			// if the URL mentions the extension of the file, the upload succeeds
 			// but if the URL is like https://source.unsplash.com/random, then the upload fails


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Will get the mime type of the imported image from the Header `Content-Type` of the image that is downloaded, if the `mime_content_type` function is available will also use that to ensure the proper type.

This will prevent fatal errors in instances where the `mime_content_type` function might not be present. 

Extended tests to also check for the attachments import.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Unit tests should pass
2. On a fresh instance where `FileInfo` PHP extension is not present
3. Check that the import of a feed as an attachment will not trigger an error.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #909.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
