### PR TITLE
Fix/706

### DIFF
--- a/cypress/e2e/gutenberg/gutenberg_free.js
+++ b/cypress/e2e/gutenberg/gutenberg_free.js
@@ -21,9 +21,9 @@ describe('Test Free - gutenberg', function() {
         cy.get('.edit-post-visual-editor__post-title-wrapper .editor-post-title__input').type(PREFIX);
 
         // insert a feedzy block
-        cy.get('div.edit-post-header__toolbar button.edit-post-header-toolbar__inserter-toggle').click({force:true});
-        cy.get('.edit-post-editor__inserter-panel-content').then(function ($popup) {
-            cy.wrap($popup).find('.components-search-control__input').type('feedzy');
+        cy.get('div.edit-post-header__toolbar button.editor-document-tools__inserter-toggle').click({force:true});
+        cy.get('.editor-inserter-sidebar__content').then(function ($popup) {
+            cy.wrap($popup).find('.components-search-control input.components-input-control__input').type('feedzy');
             cy.wrap($popup).find('.block-editor-block-types-list .editor-block-list-item-feedzy-rss-feeds-feedzy-block').should('have.length', 1);
             cy.wrap($popup).find('.block-editor-block-types-list .editor-block-list-item-feedzy-rss-feeds-feedzy-block').click({force:true});
         });
@@ -62,7 +62,7 @@ describe('Test Free - gutenberg', function() {
             // item options
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-meta input.components-text-control__input').type(gutenberg.meta, {force: true});
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-multiple-meta input.components-text-control__input').type(gutenberg.multiple_meta, {force: true});
-            /* for pro 
+            /* for pro
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-include input.components-text-control__input').type(gutenberg.include);
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-ban input.components-text-control__input').type(gutenberg.ban);
             */
@@ -116,7 +116,7 @@ describe('Test Free - gutenberg', function() {
                 // item options
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-meta input.components-text-control__input').should('have.value', gutenberg.meta);
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-multiple-meta input.components-text-control__input').should('have.value', gutenberg.multiple_meta);
-                /* for pro 
+                /* for pro
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-include input.components-text-control__input').should('have.value', gutenberg.include);
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-ban input.components-text-control__input').should('have.value', gutenberg.ban);
                 */

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -191,7 +191,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 */
 	public function feedzy_default_error_notice( $errors, $feed, $feed_url ) {
 		global $post;
-		// Show the error message only if the user who has created this post (which contains the feed) is logged in.
+		// Show the error message only if the user who has created this post (which contains the feed) is logged in and the user has admin privileges.
 		// Or if this is in the dry run window.
 		// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		$show_error = is_admin() || ( is_user_logged_in() && $post && current_user_can( 'manage_options' ) && get_current_user_id() == $post->post_author );

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -735,7 +735,6 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 * @return SimplePie|string|void|WP_Error The feed resource.
 	 */
 	public function fetch_feed( $feed_url, $cache = '12_hours', $sc = '' ) {
-        error_log('fetch_feed');
 		// Load SimplePie if not already.
 		do_action( 'feedzy_pre_http_setup', $feed_url );
 		if ( function_exists( 'feedzy_amazon_get_locale_hosts' ) ) {
@@ -755,7 +754,6 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$is_amazon_source = ! empty( $amazon_hosts ) && in_array( $url_host, $amazon_hosts, true );
 			}
 			if ( $is_amazon_source ) {
-                error_log('is_amazon_source');
 				$feed = $this->init_amazon_api(
 					$feed_url,
 					isset( $sc['refresh'] ) ? $sc['refresh'] : '12_hours',
@@ -768,10 +766,6 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 		}
 		// Load SimplePie Instance.
-        error_log('init_feed');
-        error_log(print_r($feed_url,true));
-        error_log($cache);
-        error_log(print_r($sc,true));
 		$feed = $this->init_feed( $feed_url, $cache, $sc ); // Not used as log as #41304 is Opened.
 
 		// Report error when is an error loading the feed.
@@ -909,10 +903,8 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			);
 		}
 
-        error_log('starting to init');
 		$feed->init();
 
-        error_log('init done');
 		if ( ! $feed->get_type() ) {
 			return $feed;
 		}
@@ -932,9 +924,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$feed = $this->init_feed( $feed_url, $cache, $sc, false );
 			} elseif ( is_string( $feed_url ) || ( is_array( $feed_url ) && 1 === count( $feed_url ) ) ) {
 				do_action( 'themeisle_log_event', FEEDZY_NAME, 'Trying to use raw data', 'debug', __FILE__, __LINE__ );
-                error_log('trying to use raw data');
 				$data = wp_remote_retrieve_body( wp_safe_remote_get( $feed_url, array( 'user-agent' => $default_agent ) ) );
-                error_log('got data');
 				$cloned_feed->set_raw_data( $data );
 				$cloned_feed->init();
 				$error_raw = $cloned_feed->error();

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -194,7 +194,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		// Show the error message only if the user who has created this post (which contains the feed) is logged in.
 		// Or if this is in the dry run window.
 		// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-		$show_error = is_admin() || ( is_user_logged_in() && $post && get_current_user_id() == $post->post_author );
+		$show_error = is_admin() || ( is_user_logged_in() && $post && current_user_can( 'manage_options' ) && get_current_user_id() == $post->post_author );
 		$error_msg  = '';
 
 		if ( is_array( $errors ) ) {
@@ -735,6 +735,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 * @return SimplePie|string|void|WP_Error The feed resource.
 	 */
 	public function fetch_feed( $feed_url, $cache = '12_hours', $sc = '' ) {
+        error_log('fetch_feed');
 		// Load SimplePie if not already.
 		do_action( 'feedzy_pre_http_setup', $feed_url );
 		if ( function_exists( 'feedzy_amazon_get_locale_hosts' ) ) {
@@ -754,6 +755,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$is_amazon_source = ! empty( $amazon_hosts ) && in_array( $url_host, $amazon_hosts, true );
 			}
 			if ( $is_amazon_source ) {
+                error_log('is_amazon_source');
 				$feed = $this->init_amazon_api(
 					$feed_url,
 					isset( $sc['refresh'] ) ? $sc['refresh'] : '12_hours',
@@ -766,6 +768,10 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 		}
 		// Load SimplePie Instance.
+        error_log('init_feed');
+        error_log(print_r($feed_url,true));
+        error_log($cache);
+        error_log(print_r($sc,true));
 		$feed = $this->init_feed( $feed_url, $cache, $sc ); // Not used as log as #41304 is Opened.
 
 		// Report error when is an error loading the feed.
@@ -903,8 +909,10 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			);
 		}
 
+        error_log('starting to init');
 		$feed->init();
 
+        error_log('init done');
 		if ( ! $feed->get_type() ) {
 			return $feed;
 		}
@@ -924,7 +932,9 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$feed = $this->init_feed( $feed_url, $cache, $sc, false );
 			} elseif ( is_string( $feed_url ) || ( is_array( $feed_url ) && 1 === count( $feed_url ) ) ) {
 				do_action( 'themeisle_log_event', FEEDZY_NAME, 'Trying to use raw data', 'debug', __FILE__, __LINE__ );
+                error_log('trying to use raw data');
 				$data = wp_remote_retrieve_body( wp_safe_remote_get( $feed_url, array( 'user-agent' => $default_agent ) ) );
+                error_log('got data');
 				$cloned_feed->set_raw_data( $data );
 				$cloned_feed->init();
 				$error_raw = $cloned_feed->error();

--- a/tests/test-post-access.php
+++ b/tests/test-post-access.php
@@ -74,7 +74,7 @@ class Test_Post_Access extends WP_UnitTestCase {
 		$GLOBALS['post'] = get_post( $post_id );
 		// Mock feed object and errors.
 		$feed = (object) array( 'multifeed_url' => array( 'http://example.com/feed' ) );
-		$errors = array( 'Error 1', 'Error 2' );
+		$errors = array( 'Error 1' );
 
 
 		$actual_output = $feedzy->feedzy_default_error_notice( $errors, $feed, 'http://example.com/feed' );

--- a/tests/test-post-access.php
+++ b/tests/test-post-access.php
@@ -62,4 +62,23 @@ class Test_Post_Access extends WP_UnitTestCase {
 
 	}
 
+	public function test_contributor_user_with_errors() {
+		$feedzy = new Feedzy_Rss_Feeds_Admin('feedzy', 'latest');
+		$contributor_id = $this->factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+		wp_set_current_user( $contributor_id );
+		$post_id = $this->factory->post->create( array( 'post_author' => get_current_user_id() ) );
+		$GLOBALS['post'] = get_post( $post_id );
+		// Mock feed object and errors.
+		$feed = (object) array( 'multifeed_url' => array( 'http://example.com/feed' ) );
+		$errors = array( 'Error 1', 'Error 2' );
+
+
+		$actual_output = $feedzy->feedzy_default_error_notice( $errors, $feed, 'http://example.com/feed' );
+
+		$this->assertEquals( '', $actual_output );
+	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Adds a check to display the full error only for admin users.

Adds a unit test that checks for the errors to not be displayed for non admin users.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the issue details. One important detail is that you need to test to a non admin user for example editor, author https://vertis.d.pr/i/nX0ddB . 

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/706.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
