### PR TITLE
fix: image import for images with spaces in url

### DIFF
--- a/cypress/e2e/gutenberg/gutenberg_free.js
+++ b/cypress/e2e/gutenberg/gutenberg_free.js
@@ -21,9 +21,9 @@ describe('Test Free - gutenberg', function() {
         cy.get('.edit-post-visual-editor__post-title-wrapper .editor-post-title__input').type(PREFIX);
 
         // insert a feedzy block
-        cy.get('div.edit-post-header__toolbar button.edit-post-header-toolbar__inserter-toggle').click({force:true});
-        cy.get('.edit-post-editor__inserter-panel-content').then(function ($popup) {
-            cy.wrap($popup).find('.components-search-control__input').type('feedzy');
+        cy.get('div.edit-post-header__toolbar button.editor-document-tools__inserter-toggle').click({force:true});
+        cy.get('.editor-inserter-sidebar__content').then(function ($popup) {
+            cy.wrap($popup).find('.components-search-control input.components-input-control__input').type('feedzy');
             cy.wrap($popup).find('.block-editor-block-types-list .editor-block-list-item-feedzy-rss-feeds-feedzy-block').should('have.length', 1);
             cy.wrap($popup).find('.block-editor-block-types-list .editor-block-list-item-feedzy-rss-feeds-feedzy-block').click({force:true});
         });
@@ -62,7 +62,7 @@ describe('Test Free - gutenberg', function() {
             // item options
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-meta input.components-text-control__input').type(gutenberg.meta, {force: true});
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-multiple-meta input.components-text-control__input').type(gutenberg.multiple_meta, {force: true});
-            /* for pro 
+            /* for pro
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-include input.components-text-control__input').type(gutenberg.include);
             cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-ban input.components-text-control__input').type(gutenberg.ban);
             */
@@ -116,7 +116,7 @@ describe('Test Free - gutenberg', function() {
                 // item options
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-meta input.components-text-control__input').should('have.value', gutenberg.meta);
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-multiple-meta input.components-text-control__input').should('have.value', gutenberg.multiple_meta);
-                /* for pro 
+                /* for pro
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-include input.components-text-control__input').should('have.value', gutenberg.include);
                 cy.get('div.edit-post-sidebar div.components-panel__body.feedzy-advanced-options div.components-base-control.feedzy-ban input.components-text-control__input').should('have.value', gutenberg.ban);
                 */

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1999,7 +1999,8 @@ class Feedzy_Rss_Feeds_Import {
 
 		if ( ! $id ) {
 
-			if ( filter_var( $img_source_url, FILTER_VALIDATE_URL ) === false ) {
+			// We escape the URL to ensure that valid URLs are passed by the filter.
+			if ( filter_var( esc_url( $img_source_url ), FILTER_VALIDATE_URL ) === false ) {
 				$import_errors[] = 'Invalid Featured Image URL: ' . $img_source_url;
 				return false;
 			}

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     feedzy-rss-feeds-pro
+ * @subpackage  Tests
+ * @copyright   Copyright (c) 2024, Bogdan Preda
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       4.4.6
+ */
+class Test_Image_Import extends WP_UnitTestCase {
+
+	/**
+	 * Test that the image import allows valid image URLs and logs errors for invalid ones.
+	 * Test introduced to cover this issue https://github.com/Codeinwp/feedzy-rss-feeds/issues/917.
+	 * @since 4.4.6
+	 */
+	public function test_image_import() {
+		$feedzy = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+
+		$reflector = new ReflectionClass( $feedzy );
+		$try_save_featured_image = $reflector->getMethod( 'try_save_featured_image' );
+		$try_save_featured_image->setAccessible( true );
+
+		// Check that NON-IMAGE URL returns invalid
+		$import_errors = array();
+		$import_info = array();
+		$arguments = array( 'a random string', 0, 'Post Title', &$import_errors, &$import_info, array() );
+		$response = $try_save_featured_image->invokeArgs( $feedzy, $arguments );
+
+		$this->assertFalse( $response );
+
+		$this->assertTrue( count( $import_errors ) > 0 );
+		$this->assertEquals( 'Invalid Featured Image URL: a random string', $import_errors[0] );
+
+
+		// For the next test, we will use a valid URL, but the image does not exist. We will check that the error is logged and is the expected one.
+		add_filter( 'themeisle_log_event', function( $product, $message, $type, $file, $line ) {
+			if ( $type === 'error' ) {
+				$this->assertTrue( strpos( $message, 'Unable to download file' ) !== false );
+			}
+		}, 10, 5 );
+
+		$import_errors = array();
+		$import_info = array();
+		$arguments = array( 'https://example.com/path_to_image/image.jpeg', 0, 'Post Title', &$import_errors, &$import_info, array() );
+		$response = $try_save_featured_image->invokeArgs( $feedzy, $arguments );
+
+		// expected response is false because the image does not exist, but the URL is valid so no $import_errors should be set.
+		$this->assertFalse( $response );
+		$this->assertTrue( empty( $import_errors ) );
+
+		$import_errors = array();
+		$import_info = array();
+		$arguments = array( 'https://example.com/path_to_image/image w space in name.jpeg', 0, 'Post Title', &$import_errors, &$import_info, array() );
+		$response = $try_save_featured_image->invokeArgs( $feedzy, $arguments );
+
+		// expected response is false because the image does not exist, but the URL is valid so no $import_errors should be set.
+		$this->assertFalse( $response );
+		$this->assertTrue( empty( $import_errors ) );
+	}
+}

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -15,7 +15,7 @@ class Test_Image_Import extends WP_UnitTestCase {
 	 * Test introduced to cover this issue https://github.com/Codeinwp/feedzy-rss-feeds/issues/917.
 	 * @since 4.4.6
 	 */
-	public function test_image_import() {
+	public function test_image_import_url() {
 		$feedzy = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
 
 		$reflector = new ReflectionClass( $feedzy );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixed import for images from feeds where the image might contain encoded white space in the URL.
Added unit test to check for this case.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details open>
    <summary>Mapping example for import</summary>

<img width="1291" alt="image" src="https://github.com/Codeinwp/feedzy-rss-feeds/assets/23024731/e37dcafb-ce4c-4c53-a45f-066ff8edbd8f">
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Use this feed to test with: https://fetchrss.com/rss/64e0dbc093190f2b1a5d40b264e22cf23a76e05a277d6673.xml
2. Ensure `[#item_image]` is used inside the content and featured image from mapping. See the Screenshot example.
3. Check that all images are imported.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #917.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
