### PR TITLE
fix: detailed errors for non admin access on admin screens

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -194,7 +194,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		// Show the error message only if the user who has created this post (which contains the feed) is logged in and the user has admin privileges.
 		// Or if this is in the dry run window.
 		// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-		$show_error = is_admin() || ( is_user_logged_in() && $post && current_user_can( 'manage_options' ) && get_current_user_id() == $post->post_author );
+		$show_error = ( is_admin() || ( is_user_logged_in() && $post && get_current_user_id() == $post->post_author ) ) && current_user_can( 'manage_options' );
 		$error_msg  = '';
 
 		if ( is_array( $errors ) ) {

--- a/tests/test-post-access.php
+++ b/tests/test-post-access.php
@@ -81,4 +81,25 @@ class Test_Post_Access extends WP_UnitTestCase {
 
 		$this->assertEquals( '', $actual_output );
 	}
+	public function test_author_user_with_errors_admin_screen() {
+		$feedzy = new Feedzy_Rss_Feeds_Admin('feedzy', 'latest');
+
+		$contributor_id = $this->factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		wp_set_current_user( $contributor_id );
+
+		$post_id = $this->factory->post->create( array( 'post_author' => get_current_user_id() ) );
+		$GLOBALS['post'] = get_post( $post_id );
+		// Mock feed object and errors.
+		$feed = (object) array( 'multifeed_url' => array( 'http://example.com/feed' ) );
+		$errors = array( 'Error 1' );
+
+		set_current_screen('admin.php');
+		$actual_output = $feedzy->feedzy_default_error_notice( $errors, $feed, 'http://example.com/feed' );
+
+		$this->assertEquals( '', $actual_output );
+	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Extended the user admin check when displaying errors on the plugin setup interface.

I also added a test for this particular issue.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO



### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the issue details.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/709.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
