### PR TITLE
Better checking for default image for the RSS Block

### DIFF
--- a/cypress/e2e/gutenberg/gutenberg_free.js
+++ b/cypress/e2e/gutenberg/gutenberg_free.js
@@ -207,4 +207,70 @@ describe('Test Free - gutenberg', function() {
         cy.verify_feedzy_frontend(gutenberg.results);
     });
 
+    it('Check if fallback image is hidden on feeds without image when thumnail set to "auto"', function() {
+
+        cy.visit('/wp-admin/post-new.php');
+
+        cy.wait( 1000 );
+        // get rid of that irritating popup
+        cy.get('body').then((body) => {
+            if (body.find('.edit-post-welcome-guide .components-modal__header button').length > 0) {
+              cy.get('.edit-post-welcome-guide .components-modal__header button').click({force:true});
+            }
+        });
+
+        cy.get('.edit-post-visual-editor__post-title-wrapper .editor-post-title__input').type(PREFIX);
+        
+        // Insert a Feedzy block.
+        cy.window().then(window => {
+            // Create a Feedzy block
+            const block = window.wp.blocks.createBlock('feedzy-rss-feeds/feedzy-block', {
+                feeds: 'https://themeisle.com/blog/feed/',
+                max: 2,
+            });
+            window.wp.data.dispatch( 'core/block-editor' ).insertBlock(block)
+        });
+
+        // If we have image displayed, check if the image is not the fallback image.
+        cy.get('body').then((body) => {
+            if (body.find('.feedzy-rss .rss_image').length > 0) {
+                cy.get('.feedzy-rss .rss_image').each(($el) => {
+                const imgContainer = cy.get($el).get('a span');
+                const img = imgContainer.invoke('css', 'background-image');
+            
+                // The URL should not contain 'feedzy.svg' which is the fallback image since fallback is hidden by `thumb: auto`.
+                expect(img).not.to.include('feedzy.svg');
+                });
+            }
+        });
+    });
+
+    it('Check if images are showed on feeds when thumnail is set to "yes"', function() {
+
+        cy.visit('/wp-admin/post-new.php');
+
+        cy.wait( 1000 );
+        // get rid of that irritating popup
+        cy.get('body').then((body) => {
+            if (body.find('.edit-post-welcome-guide .components-modal__header button').length > 0) {
+              cy.get('.edit-post-welcome-guide .components-modal__header button').click({force:true});
+            }
+        });
+
+        cy.get('.edit-post-visual-editor__post-title-wrapper .editor-post-title__input').type(PREFIX);
+        
+        // Insert a Feedzy block.
+        cy.window().then(window => {
+            // Create a Feedzy block
+            const block = window.wp.blocks.createBlock('feedzy-rss-feeds/feedzy-block', {
+                feeds: 'https://themeisle.com/blog/feed/',
+                max: 2,
+                thumb: 'yes',
+            });
+            window.wp.data.dispatch( 'core/block-editor' ).insertBlock(block)
+        });
+
+        cy.get('.feedzy-rss .rss_image').should('have.length', 2);
+    });
+
 })

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1438,13 +1438,12 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 		if ( 'yes' === $sc['thumb'] || 'auto' === $sc['thumb'] ) {
 			$content_thumb = '';
-			if ( 
-				( 
-					! empty( $the_thumbnail ) && 
-					'auto' === $sc['thumb'] && 
-					! strpos( $the_thumbnail, 'img/feedzy.svg' ) 
-				) || 
-				'yes' === $sc['thumb'] 
+			if ( (
+					! empty( $the_thumbnail ) &&
+					'auto' === $sc['thumb'] &&
+					! strpos( $the_thumbnail, 'img/feedzy.svg' )
+				) ||
+				'yes' === $sc['thumb']
 			) {
 				if ( ! empty( $the_thumbnail ) ) {
 					$the_thumbnail  = $this->feedzy_image_encode( $the_thumbnail );

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1438,7 +1438,14 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 		if ( 'yes' === $sc['thumb'] || 'auto' === $sc['thumb'] ) {
 			$content_thumb = '';
-			if ( ( ! empty( $the_thumbnail ) && 'auto' === $sc['thumb'] ) || 'yes' === $sc['thumb'] ) {
+			if ( 
+				( 
+					! empty( $the_thumbnail ) && 
+					'auto' === $sc['thumb'] && 
+					! strpos( $the_thumbnail, 'img/feedzy.svg' ) 
+				) || 
+				'yes' === $sc['thumb'] 
+			) {
 				if ( ! empty( $the_thumbnail ) ) {
 					$the_thumbnail  = $this->feedzy_image_encode( $the_thumbnail );
 					$content_thumb .= '<span class="fetched" style="background-image:  url(\'' . $the_thumbnail . '\');" title="' . esc_html( $item->get_title() ) . '"></span>';

--- a/includes/gutenberg/src/Editor.js
+++ b/includes/gutenberg/src/Editor.js
@@ -462,9 +462,14 @@ class Editor extends Component {
                                 }
                             }
 
-                            if ( item['thumbnail'] === '' && this.props.attributes.thumb === 'auto' ) {
+                            if ( 
+                                item['thumbnail'] === '' && 
+                                this.props.attributes.thumb === 'auto' && 
+                                ! item['default_img']?.endsWith( 'img/feedzy.svg' )
+                            ) {
                                 item['thumbnail'] = item['default_img'];
                             }
+                            
                             let meta_values = new Object();
                             meta_values['author'] = __( 'by' ) + ' ' + author;
                             meta_values['date'] = __( 'on' ) + ' ' + unescapeHTML( itemDate );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Added a checker that detects if the Feedzy default image is used when the thumbnail option is set to `auto` in the RSS block.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/e2e6c65b-dff0-4d43-bee3-ba8897d1b553)

![image](https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/618c2c06-1b9d-48f5-91cd-88804b61d1cf)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a simple import with the URL: https://themeisle.com/blog/feed/
- The default feedzy image should be shown unless it is set to show.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #920 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
