### PR TITLE
Fix/image import non ascii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cypress/screenshots/*
 cypress/integration/localhost*
 cypress/fixtures
 cypress.env.json
+.phpunit.result.cache

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -59,4 +59,23 @@ class Test_Image_Import extends WP_UnitTestCase {
 		$this->assertFalse( $response );
 		$this->assertTrue( empty( $import_errors ) );
 	}
+
+	public function test_import_image_special_characters() {
+		$feedzy = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+
+		$reflector = new ReflectionClass( $feedzy );
+		$try_save_featured_image = $reflector->getMethod( 'try_save_featured_image' );
+		$try_save_featured_image->setAccessible( true );
+
+		$import_errors = array();
+		$import_info = array();
+
+		$arguments = array( 'https://example.com/path_to_image/çöp.jpg?itok=ZYU_ihPB', 0, 'Post Title', &$import_errors, &$import_info, array() );
+		$response = $try_save_featured_image->invokeArgs( $feedzy, $arguments );
+
+		// expected response is false because the image does not exist, but the URL is valid so no $import_errors should be set.
+		$this->assertFalse( $response );
+		$this->assertTrue( empty( $import_errors ) );
+
+	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Similar to the spaces fix the URL was not passing the filter function.
Improved the URL sanitization before running the filter so that URLs are converted to ASCII and escaped.
Same as it happens inside the browser.
This should also allow for all valid URLs to pass the check.

Added test for this specific case with internalized URLs.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Try to import a feed with internalized image URLs
2. Check that the images are being imported.
3. All tests should pass.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #928.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
