### PR TITLE
feat: enable float widget from sdk

### DIFF
--- a/feedzy-rss-feed.php
+++ b/feedzy-rss-feed.php
@@ -208,3 +208,18 @@ if ( FEEDZY_LOCAL_DEBUG ) {
 }
 
 add_filter( 'themeisle_sdk_enable_telemetry', '__return_true' );
+
+add_filter(
+	'feedzy_rss_feeds_float_widget_metadata', function () {
+		return array(
+			'nice_name'          => 'Feedzy',
+			'logo'               => FEEDZY_ABSURL . 'img/feedzy.svg',
+			'primary_color'      => '#4268CF',
+			'pages'              => array( 'feedzy_imports', 'edit-feedzy_imports', 'edit-feedzy_categories', 'feedzy_page_feedzy-settings', 'feedzy_page_feedzy-support' ),
+			'has_upgrade_menu'   => ! feedzy_is_pro(),
+			'upgrade_link'       => tsdk_utmify( FEEDZY_UPSELL_LINK, 'floatWidget' ),
+			'documentation_link' => tsdk_utmify( 'https://docs.themeisle.com/collection/1569-feedzy-rss-feeds', 'floatWidget' ),
+			'wizard_link'        => ! feedzy_is_pro() && ! empty( get_option( 'feedzy_fresh_install', false ) ) ? admin_url( 'admin.php?page=feedzy-setup-wizard&tab#step-1' ) : '',
+		);
+	}
+);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Enables the Float Widget for Feedzy

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- 
- 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/themeisle#1539.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
