### PR TITLE
fix: allow user to exclude global fallback image in feed settings

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -400,7 +400,7 @@ class Feedzy_Rss_Feeds_Import {
 		$default_thumbnail_id = 0;
 		if ( feedzy_is_pro() ) {
 			$default_thumbnail_id = get_post_meta( $post->ID, 'default_thumbnail_id', true );
-			if ( empty( $default_thumbnail_id ) ) {
+			if ( empty( $default_thumbnail_id ) && '0' !== $default_thumbnail_id ) {
 				$default_thumbnail_id = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 			}
 		}
@@ -525,6 +525,9 @@ class Feedzy_Rss_Feeds_Import {
 					add_post_meta( $post_id, $key, $value );
 				}
 				if ( ! $value ) {
+					if ( 'default_thumbnail_id' === $key && '0' === $value ) {
+						continue;
+					}
 					delete_post_meta( $post_id, $key );
 				}
 			}

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -400,7 +400,10 @@ class Feedzy_Rss_Feeds_Import {
 		$default_thumbnail_id = 0;
 		if ( feedzy_is_pro() ) {
 			$default_thumbnail_id = get_post_meta( $post->ID, 'default_thumbnail_id', true );
-			if ( empty( $default_thumbnail_id ) && '0' !== $default_thumbnail_id ) {
+			if (
+				empty( $default_thumbnail_id ) &&
+				'0' !== $default_thumbnail_id // Can use the fallback image from Global Settings.
+			) {
 				$default_thumbnail_id = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 			}
 		}
@@ -525,7 +528,7 @@ class Feedzy_Rss_Feeds_Import {
 					add_post_meta( $post_id, $key, $value );
 				}
 				if ( ! $value ) {
-					if ( 'default_thumbnail_id' === $key && '0' === $value ) {
+					if ( 'default_thumbnail_id' === $key && '0' === $value ) { // Mark the feed as having no default fallback image (including the global fallback).
 						continue;
 					}
 					delete_post_meta( $post_id, $key );

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -245,6 +245,7 @@
 		feedzyAccordion();
 		feedzyTab();
 		feedzyMediaUploader();
+		initRemoveFallbackImageBtn();
 	});
 
 	function initImportScreen() {
@@ -830,15 +831,23 @@
 			$( '.feedzy-open-media' ).html( feedzy.i10n.action_btn_text_2 );
 		} ).open();
 		});
-
-		// on remove button click
-		$( 'body' ).on( 'click', '.feedzy-remove-media', function( e ) {
-			e.preventDefault();
-			var button = $( this );
-			button.parent().prev( '.feedzy-media-preview' ).remove();
-			button.removeClass( 'is-show' );
-			button.parent().find( 'input:hidden' ).val( '' ).trigger( 'change' );
-			$( '.feedzy-open-media' ).html( feedzy.i10n.action_btn_text_1 );
-		});
 	}
 }(jQuery, feedzy));
+
+/**
+ * Initialize the remove fallback image button from General Feed Settings tab.
+ */
+function initRemoveFallbackImageBtn() {
+	const removeFallbackImage = document.querySelector('.feedzy-remove-media');
+	removeFallbackImage?.addEventListener('click', (e) => {
+		e.preventDefault();
+
+		// Reset the image preview.
+		document.querySelector('.feedzy-media-preview').remove();
+		removeFallbackImage.classList.remove('is-show');
+
+		// Reset the input.
+		document.querySelector('input[name="feedzy_meta_data[default_thumbnail_id]"]').value = '0';
+		document.querySelector('.feedzy-open-media').innerHTML = feedzy.i10n.action_btn_text_1;
+	});
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

The feed setting dashboard did not have a memory to remember if the user did not want a fallback image. Thus, if you have the global fallback set, the dashboard will always use it.

After removing the fallback image from the feed settings and returning later for a short edit, if you do not re-check the fallback image settings and save, the global fallback image will be used; thus, the imported feeds will have the reported problem.

To solve this, I used the value `0` as a marking for `no fallback image`. When the user presses the `Remove` button in feed settings, `0` will be used as the image ID. The code already considered `0` as no fallback image, but it was never enabled for the user to use it.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/feedzy-rss-feeds/assets/17597852/dcba8f50-880b-4f66-ab0f-e0fd18818fe2

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Set a fallback image in General Settings
- Create a new feed; you should see the image from the global settings on the fallback image.
- Remove the image, then save.
- Re-enter the feed settings; you should not see the image from the global settings again.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/719
<!-- Should look like this: `Closes #1, #2, #3.` . -->
