### PR TITLE
fix: use the user defined custom image tag

### DIFF
--- a/cypress/e2e/default/import_feed_free.js
+++ b/cypress/e2e/default/import_feed_free.js
@@ -54,7 +54,7 @@ describe('Test Free - Import Feed', function() {
 
         cy.get('[name="feedzy_meta_data[import_post_title]"]').clear({force: true}).invoke('val', PREFIX + feed.title).blur({force: true});
         cy.get('[name="feedzy_meta_data[import_post_content]"]').clear({force: true}).invoke('val', PREFIX + feed.fullcontent.content + feed.content).blur({force: true});
-        cy.get('[name="feedzy_meta_data[import_post_featured_img]"]').clear({force: true}).invoke('val', feed.image.url).blur({force: true});
+        cy.get('[name="feedzy_meta_data[import_post_featured_img]"]').clear({force: true}).invoke('val', feed.image.tag).blur({force: true});
 
         // check disallowd magic tags
         const tags = feed.tags.disallowed;
@@ -122,7 +122,7 @@ describe('Test Free - Import Feed', function() {
         cy.get('[name="feedzy_meta_data[import_post_content]"]').should('have.value', PREFIX + feed.fullcontent.content + feed.content + '\n');
 
         // image from URL
-        cy.get('[name="feedzy_meta_data[import_post_featured_img]"]').should('have.value', feed.image.url);
+        cy.get('[name="feedzy_meta_data[import_post_featured_img]"]').should('have.value', feed.image.tag);
 
         // publish
         cy.get('button[type="submit"][name="publish"]').scrollIntoView().click({force:true});

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1652,7 +1652,7 @@ class Feedzy_Rss_Feeds_Import {
 				$image_source_url = '';
 				$img_success      = true;
 				$new_post_id      = 0;
-				$default_img_tag  = ! empty( $import_featured_img ) ? '[#item_image]' : '';
+				$default_img_tag  = ! empty( $import_featured_img ) && is_string( $import_featured_img ) ? $import_featured_img : '';
 
 				// image tag
 				if ( strpos( $default_img_tag, '[#item_image]' ) !== false ) {
@@ -1759,7 +1759,7 @@ class Feedzy_Rss_Feeds_Import {
 
 			do_action( 'feedzy_import_extra', $job, $item_obj, $new_post_id, $import_errors, $import_info );
 
-			$default_img_tag = ! empty( $import_featured_img ) ? '[#item_image]' : '';
+			$default_img_tag = ! empty( $import_featured_img ) && is_string( $import_featured_img ) ? $import_featured_img : '';
 			if ( ! empty( $default_img_tag ) && 'attachment' !== $import_post_type ) {
 				$image_source_url   = '';
 				$img_success = true;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Allow the user to use its defined custom image tag.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use this URL:  https://photojournal.jpl.nasa.gov/rss/targetFamily/Earth
- In the featured image use this: `[#item_custom_hiresJpeg]`

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/942
<!-- Should look like this: `Closes #1, #2, #3.` . -->
