### PR TITLE
chore: update create-tag node version

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -7,21 +7,19 @@ on:
 jobs:
   create_tag:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     steps:
       - uses: actions/checkout@master
         with:
           persist-credentials: false
-      - name: Build files using ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Set up Node version
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
       - name: Release new version
         id: release
         run: |
-          npm ci
           npm run release
         env:
           CI: true


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Update the Node version for 18 for `create-tag` workflow.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/931
<!-- Should look like this: `Closes #1, #2, #3.` . -->
