### PR TITLE
Fixed the issue with preview import data

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1740,6 +1740,11 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		$the_thumbnail = html_entity_decode( $the_thumbnail, ENT_QUOTES, 'UTF-8' );
+
+		if ( isset( $sc['_dryrun_'] ) && 'yes' === $sc['_dryrun_'] ) {
+			return $the_thumbnail;
+		}
+
 		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
 			$feed_url      = $this->normalize_urls( $sc['feeds'] );
 			$the_thumbnail = ! empty( $the_thumbnail ) ? $the_thumbnail : apply_filters( 'feedzy_default_image', $sc['default'], $feed_url );


### PR DESCRIPTION
### Summary
In this PR I've excluded the feedzy default thumbnail used when the user clicks on the `preview import` button.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/700
