### PR TITLE
Removed legacy magic tags from the dropdown

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2481,17 +2481,6 @@ class Feedzy_Rss_Feeds_Import {
 		$default['item_date_feed']  = __( 'Item Date (feed timezone)', 'feedzy-rss-feeds' );
 		$default['item_source']     = __( 'Item Source', 'feedzy-rss-feeds' );
 
-		// disabled tags.
-		if ( ! feedzy_is_pro() ) {
-			$default['title_spinnerchief:disabled'] = __( '🚫 Title from SpinnerChief', 'feedzy-rss-feeds' );
-			$default['title_wordai:disabled']       = __( '🚫 Title from WordAI', 'feedzy-rss-feeds' );
-
-			$default['translated_title:disabled'] = __( '🚫 Translated Title', 'feedzy-rss-feeds' );
-
-			$default['title_feedzy_rewrite:disabled'] = __( '🚫 Paraphrased Title using Feedzy', 'feedzy-rss-feeds' );
-
-		}
-
 		return $default;
 	}
 


### PR DESCRIPTION
### Summary
In this PR, I've removed the disabled legacy magic tags from the dropdown, also ensuring it does not impact existing users.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #975