### PR TITLE
Fixed PHP deprecated error

### DIFF
--- a/includes/admin/feedzy-rss-feeds-options.php
+++ b/includes/admin/feedzy-rss-feeds-options.php
@@ -48,7 +48,10 @@ if ( ! class_exists( 'Feedy_Rss_Feeds_Options' ) ) {
 		 *  Init the default values of the options class.
 		 */
 		public function init() {
-			self::$instance->options = get_option( Feedzy_Rss_Feeds::get_plugin_name() );
+			self::$instance->options = get_option( Feedzy_Rss_Feeds::get_plugin_name(), array() );
+			if ( ! is_array( self::$instance->options ) ) {
+				self::$instance->options = array();
+			}
 		}
 
 		/**


### PR DESCRIPTION
### Summary
Fixed PHP8 deprecated error. 

### Test instructions
Delete the `feedzy-rss-feeds` WordPress option or update its value, e.g., set it to an empty string or `false`.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/988
