### PR TITLE
Fixed compatibility issue with WP 6.7

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -230,7 +230,7 @@ class Feedzy_Rss_Feeds_Import {
 			'name'               => __( 'Import Posts', 'feedzy-rss-feeds' ),
 			'singular_name'      => __( 'Import Post', 'feedzy-rss-feeds' ),
 			'add_new'            => __( 'New Import', 'feedzy-rss-feeds' ),
-			'add_new_item'       => false,
+			'add_new_item'       => __( 'New Import', 'feedzy-rss-feeds' ),
 			'edit_item'          => false,
 			'new_item'           => __( 'New Import Post', 'feedzy-rss-feeds' ),
 			'view_item'          => __( 'View Import', 'feedzy-rss-feeds' ),


### PR DESCRIPTION
### Summary
Fixed missing `New Import` button text with WordPress 6.7

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #998
