### PR TITLE
feat: use content tags in import fields

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -367,10 +367,10 @@ class Feedzy_Rss_Feeds_Import {
 		$import_translation_lang  = get_post_meta( $post->ID, 'import_auto_translation_lang', true );
 		// default values so that post is not created empty.
 		if ( empty( $import_title ) ) {
-			$import_title = '[#item_title]';
+			$import_title = '[[{"value":"%5B%7B%22id%22%3A%22%22%2C%22tag%22%3A%22item_title%22%2C%22data%22%3A%7B%7D%7D%5D"}]]';
 		}
 		if ( empty( $import_content ) ) {
-			$import_content = '[#item_content]';
+			$import_content = '[[{"value":"%5B%7B%22id%22%3A%22%22%2C%22tag%22%3A%22item_content%22%2C%22data%22%3A%7B%7D%7D%5D"}]]';
 		}
 
 		$import_link_author_admin  = get_post_meta( $post->ID, 'import_link_author_admin', true );

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -436,7 +436,7 @@ global $post;
 											</div>
 											<div class="fz-input-group-right fz-title-action-tags">
 													<div class="dropdown">
-														<button type="button" class="btn btn-outline-primary btn-add-fields dropdown-toggle" 	aria-haspopup="true" aria-expanded="false">
+														<button type="button" class="btn btn-outline-primary btn-add-fields dropdown-toggle" aria-haspopup="true" aria-expanded="false">
 															<?php esc_html_e( 'Insert Tag', 'feedzy-rss-feeds' ); ?> <span class="dashicons dashicons-plus-alt2"></span>
 														</button>
 														<div class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Use visual tags instead of plain text as the default for Post Title & Content fields.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="1226" alt="Screenshot 2024-12-06 at 12 42 03 AM" src="https://github.com/user-attachments/assets/031c38fc-ceb9-41d7-b861-c183934cd411">


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the importing works as before after the change.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #1002.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
