### PR TITLE
Added image URL support

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1872,6 +1872,8 @@ class Feedzy_Rss_Feeds_Import {
 					} else {
 						$img_success = false;
 					}
+				} elseif ( wp_http_validate_url( $import_featured_img ) ) {
+					$image_source_url = $import_featured_img;
 				}
 
 				// Fetch image from graby.


### PR DESCRIPTION
### Summary
I've implemented support for image URLs, allowing users to set a fallback image URL.

![image](https://github.com/user-attachments/assets/0c70ae22-dd29-4dbc-937e-beb731a126ad)

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/918
