### PR TITLE
fix: make sure post author is assigned to imported posts

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1721,6 +1721,7 @@ class Feedzy_Rss_Feeds_Import {
 					'post_date'    => $post_date,
 					'post_status'  => $import_post_status,
 					'post_excerpt' => $item_post_excerpt,
+					'post_author'  => $job->post_author,
 				),
 				$item_obj,
 				$post_title,


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
After adding an import job to the queue, if the job was run through the cron, the post's author wasn't assigned. We make sure to always assign an author, as WordPress expects a post to have an author.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- After an import job is run through job ( You can use WP Control to simulate that) it must always have the author assigned.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #1013.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
