### PR TITLE
Added cron schedule settings per import job

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -882,22 +882,6 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			$feed->set_useragent( apply_filters( 'http_headers_useragent', $set_server_agent ) );
 		}
 
-		global $feedzy_current_error_reporting;
-		$feedzy_current_error_reporting = error_reporting();
-
-		// to avoid the Warning! Non-numeric value encountered. This can be removed once SimplePie in core is fixed.
-		if ( version_compare( phpversion(), '7.1', '>=' ) ) {
-			error_reporting( E_ALL & ~E_WARNING & ~E_DEPRECATED );
-			// reset the error_reporting back to its original value.
-			add_action(
-				'shutdown',
-				function() {
-					global $feedzy_current_error_reporting;
-					error_reporting( $feedzy_current_error_reporting );
-				}
-			);
-		}
-
 		$feed->init();
 
 		if ( ! $feed->get_type() ) {

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2380,7 +2380,7 @@ class Feedzy_Rss_Feeds_Import {
 		if ( empty( $offset ) && ! empty( $this->free_settings['general']['fz_execution_offset'] ) ) {
 			$offset = $this->free_settings['general']['fz_execution_offset'];
 		}
-		$execution = strtotime( $execution ) ? strtotime( $execution ) + ( HOUR_IN_SECONDS * $offset ) : time() + ( HOUR_IN_SECONDS * $offset );
+		$execution = strtotime( $execution ) ? strtotime( $execution ) + ( HOUR_IN_SECONDS * (int) $offset ) : time() + ( HOUR_IN_SECONDS * (int) $offset );
 		return $execution;
 	}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -406,6 +406,21 @@ class Feedzy_Rss_Feeds_Import {
 				$default_thumbnail_id = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 			}
 		}
+		$import_schedule = array(
+			'fz_execution_offset' => ! empty( $this->free_settings['general']['fz_execution_offset'] ) ? $this->free_settings['general']['fz_execution_offset'] : '',
+			'fz_cron_execution' => ! empty( $this->free_settings['general']['fz_cron_execution'] ) ? $this->free_settings['general']['fz_cron_execution'] : '',
+			'fz_cron_schedule' => ! empty( $this->free_settings['general']['fz_cron_schedule'] ) ? $this->free_settings['general']['fz_cron_schedule'] : '',
+		);
+
+		$fz_cron_execution   = get_post_meta( $post->ID, 'fz_cron_execution', true );
+		$fz_cron_schedule    = get_post_meta( $post->ID, 'fz_cron_schedule', true );
+		$fz_execution_offset = get_post_meta( $post->ID, 'fz_execution_offset', true );
+		if ( ! empty( $fz_cron_schedule ) && ! empty( $fz_cron_execution ) ) {
+			$import_schedule['fz_cron_schedule']    = $fz_cron_schedule;
+			$import_schedule['fz_execution_offset'] = $fz_execution_offset;
+			$import_schedule['fz_cron_execution']   = $fz_cron_execution;
+		}
+
 		$post_status        = $post->post_status;
 		$nonce              = wp_create_nonce( FEEDZY_BASEFILE );
 		$invalid_source_msg = apply_filters( 'feedzy_get_source_validity_error', '', $post );
@@ -473,6 +488,20 @@ class Feedzy_Rss_Feeds_Import {
 				}
 			}
 		}
+
+		$global_cron_execution = ! empty( $this->free_settings['general']['fz_cron_execution'] ) ? $this->free_settings['general']['fz_cron_execution'] : '';
+		$global_cron_schedule  = ! empty( $this->free_settings['general']['fz_cron_schedule'] ) ? $this->free_settings['general']['fz_cron_schedule'] : '';
+		if (
+			(
+				empty( $data_meta['fz_cron_execution'] ) || $global_cron_schedule === $data_meta['fz_cron_execution']
+			)
+			&&
+			empty( $data_meta['fz_cron_schedule'] ) || $global_cron_schedule === $data_meta['fz_cron_schedule']
+		) {
+			// Remove scheduled cron settings if they are equal to the global settings.
+			unset( $data_meta['fz_cron_execution'], $data_meta['fz_cron_schedule'], $data_meta['fz_execution_offset'] );
+		}
+
 		$custom_fields_keys = array();
 		if ( isset( $_POST['custom_vars_key'] ) && is_array( $_POST['custom_vars_key'] ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -543,7 +572,8 @@ class Feedzy_Rss_Feeds_Import {
 				wp_update_post( $activate );
 				add_action( 'save_post_feedzy_imports', array( $this, 'save_feedzy_import_feed_meta' ), 1, 2 );
 			}
-
+			// Clear the import job cron schedule if it exists.
+			wp_clear_scheduled_hook( 'feedzy_cron', array( 100, $post_id ) );
 			do_action( 'feedzy_save_fields', $post_id, $post );
 		}
 
@@ -724,20 +754,33 @@ class Feedzy_Rss_Feeds_Import {
 
 				break;
 			case 'feedzy-next_run':
-				$next = wp_next_scheduled( 'feedzy_cron' );
+				$next = wp_next_scheduled( 'feedzy_cron', array( 100, $post_id ) );
+				if ( ! $next ) {
+					$next = wp_next_scheduled( 'feedzy_cron' );
+				}
 				if ( $next ) {
 					$now  = new DateTime();
 					$then = new DateTime();
 					$then = $then->setTimestamp( $next );
 					$in   = $now->diff( $then );
-					echo wp_kses_post(
-						sprintf(
-							// translators: %1$d: number of hours, %2$d: number of minutes
-							__( 'In %1$d hours %2$d minutes', 'feedzy-rss-feeds' ),
-							$in->format( '%h' ),
-							$in->format( '%i' )
-						)
-					);
+
+					$time_string = array();
+					// Add days if they exist.
+					if ( $in->d > 0 ) {
+						// translators: %1$s days.
+						$time_string[] = sprintf( __( '%1$d days', 'feedzy-rss-feeds' ), $in->d );
+					}
+					// Add hours if they exist.
+					if ( $in->h > 0 ) {
+						// translators: %1$s hours.
+						$time_string[] = sprintf( __( '%1$d hours', 'feedzy-rss-feeds' ), $in->h );
+					}
+					// Add minutes if they exist.
+					if ( $in->i > 0 ) {
+						// translators: %1$s minutes.
+						$time_string[] = sprintf( __( '%1$d minutes', 'feedzy-rss-feeds' ), $in->i );
+					}
+					echo wp_kses_post( join( ' ', $time_string ) );
 				}
 				break;
 			default:
@@ -1223,7 +1266,7 @@ class Feedzy_Rss_Feeds_Import {
 	 * @since   1.2.0
 	 * @access  public
 	 */
-	public function run_cron( $max = 100 ) {
+	public function run_cron( $max = 100, $job_id = 0 ) {
 		if ( empty( $max ) ) {
 			$max = 10;
 		}
@@ -1234,8 +1277,25 @@ class Feedzy_Rss_Feeds_Import {
 				'post_type'   => 'feedzy_imports',
 				'post_status' => 'publish',
 				'numberposts' => 99,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					'relation' => 'AND',
+					array(
+						'key'     => 'fz_cron_execution',
+						'compare' => 'NOT EXISTS',
+					),
+					array(
+						'key'     => 'fz_cron_schedule',
+						'compare' => 'NOT EXISTS',
+					),
+				),
 			)
 		);
+
+		if ( $job_id ) {
+			$args['post__in'] = array( $job_id );
+			unset( $args['meta_query'], $args['numberposts'] );
+		}
 
 		$feedzy_imports = get_posts( $args );
 		foreach ( $feedzy_imports as $job ) {
@@ -2271,6 +2331,40 @@ class Feedzy_Rss_Feeds_Import {
 		}
 		if ( false === wp_next_scheduled( 'feedzy_cron' ) ) {
 			wp_schedule_event( $time, $schedule, 'feedzy_cron' );
+		}
+
+		// Register import jobs based cron jobs.
+		$import_job_crons = get_posts(
+			array(
+				'post_type'   => 'feedzy_imports',
+				'post_status' => 'publish',
+				'numberposts' => 99,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'meta_query'  => array(
+					'relation' => 'AND',
+					array(
+						'key'     => 'fz_cron_execution',
+						'compare' => 'EXISTS',
+					),
+					array(
+						'key'     => 'fz_cron_schedule',
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		if ( ! empty( $import_job_crons ) ) {
+			foreach ( $import_job_crons as $import_job_cron ) {
+				$fz_cron_execution   = get_post_meta( $import_job_cron->ID, 'fz_cron_execution', true );
+				$fz_cron_schedule    = get_post_meta( $import_job_cron->ID, 'fz_cron_schedule', true );
+				$fz_execution_offset = get_post_meta( $import_job_cron->ID, 'fz_execution_offset', true );
+				$time                = $this->get_cron_execution( $fz_cron_execution, $fz_execution_offset );
+
+				if ( false === wp_next_scheduled( 'feedzy_cron', array( 100, $import_job_cron->ID ) ) ) {
+					wp_schedule_event( $time, $fz_cron_schedule, 'feedzy_cron', array( 100, $import_job_cron->ID ) );
+				}
+			}
 		}
 	}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2339,6 +2339,7 @@ class Feedzy_Rss_Feeds_Import {
 				'post_type'   => 'feedzy_imports',
 				'post_status' => 'publish',
 				'numberposts' => 99,
+				'fields'      => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'  => array(
 					'relation' => 'AND',
@@ -2355,14 +2356,14 @@ class Feedzy_Rss_Feeds_Import {
 		);
 
 		if ( ! empty( $import_job_crons ) ) {
-			foreach ( $import_job_crons as $import_job_cron ) {
-				$fz_cron_execution   = get_post_meta( $import_job_cron->ID, 'fz_cron_execution', true );
-				$fz_cron_schedule    = get_post_meta( $import_job_cron->ID, 'fz_cron_schedule', true );
-				$fz_execution_offset = get_post_meta( $import_job_cron->ID, 'fz_execution_offset', true );
+			foreach ( $import_job_crons as $job_id ) {
+				$fz_cron_execution   = get_post_meta( $job_id, 'fz_cron_execution', true );
+				$fz_cron_schedule    = get_post_meta( $job_id, 'fz_cron_schedule', true );
+				$fz_execution_offset = get_post_meta( $job_id, 'fz_execution_offset', true );
 				$time                = $this->get_cron_execution( $fz_cron_execution, $fz_execution_offset );
 
-				if ( false === wp_next_scheduled( 'feedzy_cron', array( 100, $import_job_cron->ID ) ) ) {
-					wp_schedule_event( $time, $fz_cron_schedule, 'feedzy_cron', array( 100, $import_job_cron->ID ) );
+				if ( false === wp_next_scheduled( 'feedzy_cron', array( 100, $job_id ) ) ) {
+					wp_schedule_event( $time, $fz_cron_schedule, 'feedzy_cron', array( 100, $job_id ) );
 				}
 			}
 		}

--- a/includes/feedzy-rss-feeds.php
+++ b/includes/feedzy-rss-feeds.php
@@ -229,7 +229,7 @@ class Feedzy_Rss_Feeds {
 			self::$instance->loader->add_action( 'admin_enqueue_scripts', $plugin_import, 'enqueue_styles' );
 			self::$instance->loader->add_action( 'init', $plugin_import, 'register_import_post_type', 9, 1 );
 			self::$instance->loader->add_action( 'add_meta_boxes', $plugin_import, 'add_feedzy_import_metaboxes', 1, 2 );
-			self::$instance->loader->add_action( 'feedzy_cron', $plugin_import, 'run_cron' );
+			self::$instance->loader->add_action( 'feedzy_cron', $plugin_import, 'run_cron', 10, 2 );
 			self::$instance->loader->add_action( 'save_post_feedzy_imports', $plugin_import, 'save_feedzy_import_feed_meta', 1, 2 );
 			self::$instance->loader->add_action( 'wp_ajax_feedzy', $plugin_import, 'ajax' );
 			self::$instance->loader->add_action( 'manage_feedzy_imports_posts_custom_column', $plugin_import, 'manage_feedzy_import_columns', 10, 2 );

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -835,6 +835,56 @@ global $post;
 							</div>
 						</div>
 					</div>
+					<?php if ( feedzy_is_pro() ) : ?>
+						<div class="form-block form-block-two-column">
+						<div class="fz-left">
+							<h4 class="h4"><?php esc_html_e( 'Schedule Import Job', 'feedzy-rss-feeds' ); ?></h4>
+						</div>
+						<div class="fz-right">
+							<div class="fz-form-row">
+								<div class="fz-form-col-6">
+									<div class="fz-form-group">
+										<label class="form-label"><?php esc_html_e( 'First cron execution time', 'feedzy-rss-feeds' ); ?></label>
+										<input type="hidden" name="feedzy_meta_data[fz_execution_offset]" id="fz-execution-offset" value="<?php echo ! empty( $import_schedule['fz_execution_offset'] ) ? esc_attr( $import_schedule['fz_execution_offset'] ) : ''; ?>">
+										<input type="datetime-local" id="fz-event-execution" name="feedzy_meta_data[fz_cron_execution]" class="form-control" value="<?php echo ! empty( $import_schedule['fz_cron_execution'] ) ? esc_attr( $import_schedule['fz_cron_execution'] ) : ''; ?>">
+										<div class="help-text pt-8">
+											<?php esc_html_e( 'When past date will be provided, event will be executed in the next queue.', 'feedzy-rss-feeds' ); ?>
+											<a href="<?php echo esc_url( 'https://docs.themeisle.com/article/1820-how-to-set-scheduler-for-import-cron-jobs-in-feedzy' ); ?>" target="_blank"><?php esc_html_e( 'Learn More', 'feedzy-rss-feeds' ); ?></a>
+										</div>
+									</div>
+								</div>
+								<div class="fz-form-col-6">
+									<div class="fz-form-group">
+										<label class="form-label"><?php esc_html_e( 'Schedule', 'feedzy-rss-feeds' ); ?></label>
+										<?php
+										$save_schedule = ! empty( $import_schedule['fz_cron_schedule'] ) ? $import_schedule['fz_cron_schedule'] : '';
+
+										$schedules = wp_get_schedules();
+										if ( isset( $schedules['hourly'] ) ) {
+											$hourly = $schedules['hourly'];
+											unset( $schedules['hourly'] );
+											$schedules = array_merge( array( 'hourly' => $hourly ), $schedules );
+										}
+										?>
+										<select id="fz-event-schedule" class="form-control fz-select-control" name="feedzy_meta_data[fz_cron_schedule]">
+											<?php
+											$duplicate_schedule = array();
+											foreach ( $schedules as $slug => $schedule ) :
+												if ( empty( $schedule['interval'] ) || in_array( $schedule['interval'], $duplicate_schedule, true ) ) {
+													continue;
+												}
+												$duplicate_schedule[] = $schedule['interval'];
+												?>
+												<option value="<?php echo esc_attr( $slug ); ?>"<?php selected( $save_schedule, $slug ); ?>><?php echo esc_html( $schedule['display'] ); ?> (<?php echo esc_html( $slug ); ?>)</option>
+											<?php endforeach; ?>
+										</select>
+										<div class="help-text pt-8"><?php esc_html_e( 'After first execution repeat.', 'feedzy-rss-feeds' ); ?></div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<?php endif; ?>
 					<?php if ( function_exists( 'icl_get_languages' ) ) : ?>
 						<div class="form-block form-block-two-column">
 							<div class="fz-left">

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -836,7 +836,7 @@ global $post;
 						</div>
 					</div>
 					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
-						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-image', 'import' ) ); ?>
+						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'schedule-import-job', 'import' ) ); ?>
 						<div class="fz-left">
 							<h4 class="h4"><?php esc_html_e( 'Schedule Import Job', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 						</div>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -835,18 +835,20 @@ global $post;
 							</div>
 						</div>
 					</div>
-					<?php if ( feedzy_is_pro() ) : ?>
-						<div class="form-block form-block-two-column">
+					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
+						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-image', 'import' ) ); ?>
 						<div class="fz-left">
-							<h4 class="h4"><?php esc_html_e( 'Schedule Import Job', 'feedzy-rss-feeds' ); ?></h4>
+							<h4 class="h4"><?php esc_html_e( 'Schedule Import Job', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 						</div>
 						<div class="fz-right">
 							<div class="fz-form-row">
 								<div class="fz-form-col-6">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'First cron execution time', 'feedzy-rss-feeds' ); ?></label>
-										<input type="hidden" name="feedzy_meta_data[fz_execution_offset]" id="fz-execution-offset" value="<?php echo ! empty( $import_schedule['fz_execution_offset'] ) ? esc_attr( $import_schedule['fz_execution_offset'] ) : ''; ?>">
-										<input type="datetime-local" id="fz-event-execution" name="feedzy_meta_data[fz_cron_execution]" class="form-control" value="<?php echo ! empty( $import_schedule['fz_cron_execution'] ) ? esc_attr( $import_schedule['fz_cron_execution'] ) : ''; ?>">
+										<?php if ( feedzy_is_pro() ) : ?>
+											<input type="hidden" name="feedzy_meta_data[fz_execution_offset]" id="fz-execution-offset" value="<?php echo ! empty( $import_schedule['fz_execution_offset'] ) ? esc_attr( $import_schedule['fz_execution_offset'] ) : ''; ?>">
+										<?php endif; ?>
+										<input type="datetime-local" id="fz-event-execution" name="feedzy_meta_data[fz_cron_execution]" class="form-control" value="<?php echo ! empty( $import_schedule['fz_cron_execution'] ) ? esc_attr( $import_schedule['fz_cron_execution'] ) : ''; ?>"<?php disabled( true, ! feedzy_is_pro() ); ?>>
 										<div class="help-text pt-8">
 											<?php esc_html_e( 'When past date will be provided, event will be executed in the next queue.', 'feedzy-rss-feeds' ); ?>
 											<a href="<?php echo esc_url( 'https://docs.themeisle.com/article/1820-how-to-set-scheduler-for-import-cron-jobs-in-feedzy' ); ?>" target="_blank"><?php esc_html_e( 'Learn More', 'feedzy-rss-feeds' ); ?></a>
@@ -856,18 +858,16 @@ global $post;
 								<div class="fz-form-col-6">
 									<div class="fz-form-group">
 										<label class="form-label"><?php esc_html_e( 'Schedule', 'feedzy-rss-feeds' ); ?></label>
-										<?php
-										$save_schedule = ! empty( $import_schedule['fz_cron_schedule'] ) ? $import_schedule['fz_cron_schedule'] : '';
-
-										$schedules = wp_get_schedules();
-										if ( isset( $schedules['hourly'] ) ) {
-											$hourly = $schedules['hourly'];
-											unset( $schedules['hourly'] );
-											$schedules = array_merge( array( 'hourly' => $hourly ), $schedules );
-										}
-										?>
-										<select id="fz-event-schedule" class="form-control fz-select-control" name="feedzy_meta_data[fz_cron_schedule]">
+										<select id="fz-event-schedule" class="form-control fz-select-control" name="feedzy_meta_data[fz_cron_schedule]"<?php disabled( true, ! feedzy_is_pro() ); ?>>
 											<?php
+											$save_schedule = ! empty( $import_schedule['fz_cron_schedule'] ) ? $import_schedule['fz_cron_schedule'] : '';
+
+											$schedules = wp_get_schedules();
+											if ( isset( $schedules['hourly'] ) ) {
+												$hourly = $schedules['hourly'];
+												unset( $schedules['hourly'] );
+												$schedules = array_merge( array( 'hourly' => $hourly ), $schedules );
+											}
 											$duplicate_schedule = array();
 											foreach ( $schedules as $slug => $schedule ) :
 												if ( empty( $schedule['interval'] ) || in_array( $schedule['interval'], $duplicate_schedule, true ) ) {
@@ -884,7 +884,6 @@ global $post;
 							</div>
 						</div>
 					</div>
-					<?php endif; ?>
 					<?php if ( function_exists( 'icl_get_languages' ) ) : ?>
 						<div class="form-block form-block-two-column">
 							<div class="fz-left">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -38,9 +38,6 @@
         <exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
         <exclude name="WordPress.PHP.DevelopmentFunctions.error_log_print_r" />
         <exclude name="WordPress.WP.AlternativeFunctions" />
-        <exclude name="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set" />
-        <exclude name="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting" />
-        <exclude name="WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting" />
         <exclude name="WordPress.PHP.DevelopmentFunctions.error_log_error_log" />
     </rule>
     <config name="testVersion" value="7.2-" />

--- a/tests/e2e/specs/upsell.spec.js
+++ b/tests/e2e/specs/upsell.spec.js
@@ -65,5 +65,9 @@ test.describe( 'Upsell', () => {
         await page.locator('.fz-form-group:has( #feed-post-default-thumbnail )').hover({ force: true });
         upgradeAlert = page.locator('#feedzy-import-form a[href*="utm_campaign=fallback-image"]');
         await expect( upgradeAlert ).toBeVisible();
+
+        await page.locator('.fz-form-group:has( #fz-event-execution )').hover({ force: true });
+        upgradeAlert = page.locator('#feedzy-import-form a[href*="utm_campaign=schedule-import-job"]');
+        await expect( upgradeAlert ).toBeVisible();
     } );
 });


### PR DESCRIPTION
### Summary
Adds new cron schedule settings for per import job.

### Will affect visual aspect of the product
Yes

### Screenshots
![image](https://github.com/user-attachments/assets/85010a8a-4444-44ff-908a-23b5ca3a5d95)

### Test instructions
- Create an import job and configure a custom cron schedule.
- Wait for the default job to trigger, or install the WP-Control plugin to manually trigger the cron.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/572
