### PR TITLE
feat: add post author selection to Feed Imports

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -614,6 +614,15 @@ fieldset[disabled] .form-control {
 	background: #D0D4D7;
 }
 
+.fz-form-wrap .chosen-container .chosen-results li.helper-text {
+	display: block;
+	background: white;
+	cursor: help;
+	font-size: 12px;
+	text-align: center;
+	color: #757575;
+}
+
 .date-range-group{
 	display: flex;
 	align-items: flex-end;

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -603,6 +603,26 @@ global $post;
 								</div>
 								<div class="fz-right">
 									<div class="fz-form-group">
+										<label class="form-label"><?php esc_html_e( 'The post author for the imported posts.', 'feedzy-rss-feeds' ); ?></label>
+										<div class="mx-320">
+											<select id="feedzy_post_author" class="form-control feedzy-chosen fz-chosen-custom-tag" name="feedzy_meta_data[import_post_author]">
+												<?php
+												foreach ( $authors_array as $_author ) {
+													?>
+												<option value="<?php echo esc_attr( $_author ); ?>" <?php selected( $import_post_author, $_author ); ?>>
+													<?php echo esc_html( $_author ); ?></option>
+													<?php
+												}
+												?>
+											</select>
+										</div>
+										<div class="help-text pt-8 pb-8">
+											<?php
+												esc_html_e( 'Select the author to assign to the imported posts. By default, this will be set to your current account. Note that this choice is independent of the options below, which control how the source author details are displayed.', 'feedzy-rss-feeds' );
+											?>
+										</div>
+									</div>
+									<div class="fz-form-group">
 										<div class="fz-form-switch">
 											<input id="feedzy-toggle_author_admin" name="feedzy_meta_data[import_link_author_admin]"
 												class="fz-switch-toggle" type="checkbox" value="yes"

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -327,6 +327,34 @@
 			}
 		})
 
+		// Add magic tag support for post taxonomy field.
+		$("#feedzy_post_author.fz-chosen-custom-tag").on("chosen:no_results", function() {
+			var select = $(this);
+			var search = select.siblings(".chosen-container").find(".chosen-search-input");
+			var text = htmlEntities(search.val().replace(/\s+/g, ''));
+			// dont add if it already exists
+			if (! select.find('option[value=' + escapeSelector(search.val().replace(/\s+/g, '')) + ']').length) {
+				var btn = $('<li class="active-result highlighted">' + text + '</li>');
+				btn.on("mousedown mouseup click", function(e) {
+					var arr = select.val() || [];
+					select.append("<option value='" + text + "' selected>" + text + "</option>");
+					select.trigger("chosen:updated").trigger('chosen:close');
+					e.stopImmediatePropagation();
+					return false;
+				});
+				search.on("keydown", function(e) {
+					if (e.which == 13) {
+						btn.click();
+						return false;
+					}
+				});
+				select.siblings(".chosen-container").find(".no-results").replaceWith(btn);
+				select.siblings(".chosen-container").find(".chosen-results").append('<li class="helper-text">' + feedzy.i10n.author_helper + '</li>');
+			} else {
+				select.siblings(".chosen-container").find(".no-results").replaceWith('');
+			}
+		})
+
 		/*
          Form
          */


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This adds a select field to choose the author for the imported posts in Feed import. If the author is not available in the list, as we only load 100 users, a custom username can also be typed there.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
Yes

### Screenshots <!-- if applicable -->

<img width="1211" alt="Screenshot 2024-12-16 at 2 21 30 PM" src="https://github.com/user-attachments/assets/18243a28-0eb9-4812-8e6a-b4ed84010c47" />

<img width="1207" alt="Screenshot 2024-12-16 at 2 21 47 PM" src="https://github.com/user-attachments/assets/85f2ccf9-6f81-44fc-8365-f10be1d66ed9" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- We need to confirm the selected user is used as the author of imported posts.
- We should also make sure it works properly when upgrading from previous version.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/720.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
