### PR TITLE
feat: improve external featured image handling

### DIFF
--- a/includes/feedzy-rss-feeds-feed-tweaks.php
+++ b/includes/feedzy-rss-feeds-feed-tweaks.php
@@ -161,7 +161,7 @@ add_filter( 'elementor/image_size/get_attachment_image_html', 'feedzy_el_display
  * @param int|false        $thumbnail_id  Post thumbnail ID or false if the post does not exist.
  * @return bool
  */
-function enable_external_url_support( $has_thumbnail, $post, $thumbnail_id ) {
+function feedzy_enable_external_url_support( $has_thumbnail, $post, $thumbnail_id ) {
 	$post_id = get_the_ID();
 	if ( $post && is_object( $post ) ) {
 		$post_id = $post->ID;
@@ -175,7 +175,28 @@ function enable_external_url_support( $has_thumbnail, $post, $thumbnail_id ) {
 	}
 	return $has_thumbnail;
 }
-add_filter( 'has_post_thumbnail', 'enable_external_url_support', 10, 3 );
+add_filter( 'has_post_thumbnail', 'feedzy_enable_external_url_support', 10, 3 );
+
+/**
+ * Filters the attachment image source.
+ *
+ * @param array|false  $image         Either array with src, width & height, icon src, or false.
+ * @param int          $attachment_id Image attachment ID.
+ * @param string|int[] $size          Size of image. Image size or array of width and height values (in that order).
+ * @param bool         $icon          Whether the image should be treated as an icon.
+ * @return array|false
+ */
+function feedzy_get_attachment_image_src( $image, $attachment_id, $size, $icon ) {
+	if ( 0 === $attachment_id ) {
+		$external_url = get_post_meta( get_the_ID(), 'feedzy_item_external_url', true );
+		if ( $external_url ) {
+			$image = array( $external_url, 0, 0, false );
+		}
+	}
+	return $image;
+}
+
+add_filter( 'wp_get_attachment_image_src', 'feedzy_get_attachment_image_src', 10, 4 );
 
 /**
  * Boostrap the plugin view.


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This PR uses the `wp_get_attachment_image_src` filter to make `wp_get_attachment_image_url` return the external URL for featured image.

Unrelated, I also prefixed an existing function with `feedzy_` to avoid possible conflicts.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- It should improve featured image handling with various third-party post grid/layout plugins that use `wp_get_attachment_image_url`
- For example, you can use Essential Addons for Elementor and their Timeline Block's Card Layout.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/738.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
