### PR TITLE
feat: use action scheduler when available

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -573,7 +573,7 @@ class Feedzy_Rss_Feeds_Import {
 				add_action( 'save_post_feedzy_imports', array( $this, 'save_feedzy_import_feed_meta' ), 1, 2 );
 			}
 			// Clear the import job cron schedule if it exists.
-			wp_clear_scheduled_hook( 'feedzy_cron', array( 100, $post_id ) );
+			Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron', array( 100, $post_id ) );
 			do_action( 'feedzy_save_fields', $post_id, $post );
 		}
 
@@ -754,9 +754,9 @@ class Feedzy_Rss_Feeds_Import {
 
 				break;
 			case 'feedzy-next_run':
-				$next = wp_next_scheduled( 'feedzy_cron', array( 100, $post_id ) );
+				$next = Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', array( 100, $post_id ) );
 				if ( ! $next ) {
-					$next = wp_next_scheduled( 'feedzy_cron' );
+					$next = Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron' );
 				}
 				if ( $next ) {
 					$now  = new DateTime();
@@ -2326,11 +2326,11 @@ class Feedzy_Rss_Feeds_Import {
 				$offset    = sanitize_text_field( wp_unslash( $_POST['fz_execution_offset'] ) );
 				$time      = $this->get_cron_execution( $execution, $offset );
 				$schedule  = sanitize_text_field( wp_unslash( $_POST['fz_cron_schedule'] ) );
-				wp_clear_scheduled_hook( 'feedzy_cron' );
+				Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron' );
 			}
 		}
-		if ( false === wp_next_scheduled( 'feedzy_cron' ) ) {
-			wp_schedule_event( $time, $schedule, 'feedzy_cron' );
+		if ( false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron' ) ) {
+			Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $time, $schedule, 'feedzy_cron' );
 		}
 
 		// Register import jobs based cron jobs.
@@ -2362,8 +2362,8 @@ class Feedzy_Rss_Feeds_Import {
 				$fz_execution_offset = get_post_meta( $job_id, 'fz_execution_offset', true );
 				$time                = $this->get_cron_execution( $fz_cron_execution, $fz_execution_offset );
 
-				if ( false === wp_next_scheduled( 'feedzy_cron', array( 100, $job_id ) ) ) {
-					wp_schedule_event( $time, $fz_cron_schedule, 'feedzy_cron', array( 100, $job_id ) );
+				if ( false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', array( 100, $job_id ) ) ) {
+					Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $time, $fz_cron_schedule, 'feedzy_cron', array( 100, $job_id ) );
 				}
 			}
 		}
@@ -2401,7 +2401,7 @@ class Feedzy_Rss_Feeds_Import {
 			echo wp_kses_post( '<div class="notice notice-error feedzy-error-critical is-dismissible"><p>' . __( 'WP Cron is disabled. Your feeds would not get updated. Please contact your hosting provider or system administrator', 'feedzy-rss-feeds' ) . '</p></div>' );
 		}
 
-		if ( false === wp_next_scheduled( 'feedzy_cron' ) ) {
+		if ( false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron' ) ) {
 			echo wp_kses_post( '<div class="notice notice-error"><p>' . __( 'Unable to register cron job. Your feeds might not get updated', 'feedzy-rss-feeds' ) . '</p></div>' );
 		}
 	}

--- a/includes/util/feedzy-rss-feeds-util-scheduler.php
+++ b/includes/util/feedzy-rss-feeds-util-scheduler.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * The class that contains utility functions for scheduling tasks.
+ *
+ * @link       https://themeisle.com
+ *
+ * @package    feedzy-rss-feeds
+ * @subpackage feedzy-rss-feeds/includes/util
+ */
+
+/**
+ * The class that contains utility functions for scheduling tasks.
+ *
+ * Class that contains utility functions for scheduling tasks.
+ *
+ * @package    feedzy-rss-feeds
+ * @subpackage feedzy-rss-feeds/includes/util
+ * @author     Themeisle <friends@themeisle.com>
+ */
+class Feedzy_Rss_Feeds_Util_Scheduler {
+
+	/**
+	 * Check if an action hook is scheduled.
+	 *
+	 * @param string $hook The hook to check.
+	 * @param array  $args Optional. Arguments to pass to the hook
+	 *
+	 * @return bool
+	 */
+	public static function is_scheduled( $hook, $args = array() ) {
+		if ( function_exists( 'as_has_scheduled_action' ) ) {
+			return as_has_scheduled_action( $hook, $args );
+		}
+
+		if ( function_exists( 'as_next_scheduled_action' ) ) {
+			// For older versions of AS.
+			return as_next_scheduled_action( $hook, $args ) !== false;
+		}
+
+		return wp_next_scheduled( $hook, $args ) !== false;
+	}
+
+	/**
+	 * Clear scheduled hook.
+	 *
+	 * @param string $hook The name of the hook to clear.
+	 * @param array  $args Optional. Arguments that were to be passed to the hook's callback function. Default empty array.
+	 * @return mixed The scheduled action ID if a scheduled action was found, or null if no matching action found. If WP_Cron is used, on success an integer indicating number of events unscheduled, false or WP_Error if unscheduling one or more events fail.
+	 */
+	public static function clear_scheduled_hook( $hook, $args = array() ) {
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			return as_unschedule_all_actions( $hook, $args );
+		}
+
+		return wp_clear_scheduled_hook( $hook, $args );
+	}
+
+	/**
+	 * Schedule an event.
+	 *
+	 * @param int    $time       The first time that the event will occur.
+	 * @param string $recurrence How often the event should recur. See wp_get_schedules() for accepted values.
+	 * @param string $hook       The name of the hook that will be triggered by the event.
+	 * @param array  $args       Optional. Arguments to pass to the hook's callback function. Default empty array.
+	 * @return integer|bool|WP_Error The action ID if Action Scheduler is used. True if event successfully scheduled, False or WP_Error on failure if WP Cron is used.
+	 */
+	public static function schedule_event( $time, $recurrence, $hook, $args = array() ) {
+		if ( function_exists( 'as_schedule_recurring_action' ) ) {
+			$schedules = wp_get_schedules();
+			if ( isset( $schedules[ $recurrence ] ) ) {
+				$interval = $schedules[ $recurrence ]['interval'];
+				return as_schedule_recurring_action( $time, $interval, $hook, $args );
+			}
+		}
+
+		return wp_schedule_event( $time, $recurrence, $hook, $args );
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This PR creates wrapper functions for WP_Cron in order to use Action Scheduler when available.

**Note:** This PR is made against https://github.com/Codeinwp/feedzy-rss-feeds/pull/1028 to cover latest cron uses added by the PR, and must be merged against the PR or to development after the initial PR is merged.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
No

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Cron should work as before.
- To test with Action Scheduler, you can install WooCommerce and then use the plugin.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [X] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/785.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
