### PR TITLE
Adds multiple fallback images support

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1437,10 +1437,10 @@ class Feedzy_Rss_Feeds_Import {
 		}
 
 		// Get default thumbnail ID.
-		$default_thumbnail = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
+		$global_fallback_thumbnail = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 		if ( feedzy_is_pro() ) {
 			$default_thumbnail = get_post_meta( $job->ID, 'default_thumbnail_id', true );
-			$default_thumbnail = ! empty( $default_thumbnail ) ? explode( ',', (string) $default_thumbnail ) : array();
+			$default_thumbnail = ! empty( $default_thumbnail ) ? explode( ',', (string) $default_thumbnail ) : $global_fallback_thumbnail;
 		}
 
 		// Note: this implementation will only work if only one of the fields is allowed to provide

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -165,6 +165,8 @@ class Feedzy_Rss_Feeds_Import {
 						'clearLogButton'      => __( 'Clear Log', 'feedzy-rss-feeds' ),
 						'okButton'            => __( 'Ok', 'feedzy-rss-feeds' ),
 						'removeErrorLogsMsg'  => __( 'Removed all error logs.', 'feedzy-rss-feeds' ),
+						// translators: %d select images count.
+						'action_btn_text_3'   => __( '(%d) images selected', 'feedzy-rss-feeds' ),
 					),
 				)
 			);
@@ -512,6 +514,9 @@ class Feedzy_Rss_Feeds_Import {
 				} else {
 					if ( 'import_post_content' === $key ) {
 						$val = feedzy_custom_tag_escape( $val );
+					} elseif ( 'default_thumbnail_id' === $key && ! empty( $val ) ) {
+						$val = explode( ',', $val );
+						$val = array_map( 'intval', $val );
 					} else {
 						$val = wp_kses( $val, apply_filters( 'feedzy_wp_kses_allowed_html', array() ) );
 					}
@@ -1435,6 +1440,7 @@ class Feedzy_Rss_Feeds_Import {
 		$default_thumbnail = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 		if ( feedzy_is_pro() ) {
 			$default_thumbnail = get_post_meta( $job->ID, 'default_thumbnail_id', true );
+			$default_thumbnail = ! empty( $default_thumbnail ) ? explode( ',', (string) $default_thumbnail ) : array();
 		}
 
 		// Note: this implementation will only work if only one of the fields is allowed to provide
@@ -2073,6 +2079,10 @@ class Feedzy_Rss_Feeds_Import {
 
 				// Set default thumbnail image.
 				if ( ! $img_success && ! empty( $default_thumbnail ) ) {
+					if ( is_array( $default_thumbnail ) ) {
+						shuffle( $default_thumbnail );
+						$default_thumbnail = reset( $default_thumbnail );
+					}
 					$img_success = set_post_thumbnail( $new_post_id, $default_thumbnail );
 				}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2080,10 +2080,12 @@ class Feedzy_Rss_Feeds_Import {
 				// Set default thumbnail image.
 				if ( ! $img_success && ! empty( $default_thumbnail ) ) {
 					if ( is_array( $default_thumbnail ) ) {
-						shuffle( $default_thumbnail );
-						$default_thumbnail = reset( $default_thumbnail );
+						$random_key           = array_rand( $default_thumbnail );
+						$default_thumbnail_id = isset( $default_thumbnail[ $random_key ] ) ? $default_thumbnail[ $random_key ] : 0;
+					} else {
+						$default_thumbnail_id = $default_thumbnail;
 					}
-					$img_success = set_post_thumbnail( $new_post_id, $default_thumbnail );
+					$img_success = set_post_thumbnail( $new_post_id, $default_thumbnail_id );
 				}
 
 				if ( ! $img_success ) {

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -665,21 +665,37 @@ global $post;
 							<div class="fz-form-group">
 								<label class="form-label"><?php esc_html_e( 'Select an image to be the fallback featured image.', 'feedzy-rss-feeds' ); ?></label>
 								<?php
-								$btn_label = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
-								if ( $default_thumbnail_id ) :
+								$btn_label            = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
+								$default_thumbnail_id = ! empty( $default_thumbnail_id ) ? explode( ',', (string) $default_thumbnail_id ) : array();
+								if ( ! empty( $default_thumbnail_id ) ) :
 									$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
 									?>
 									<div class="fz-form-group mb-20 feedzy-media-preview">
-										<?php echo wp_get_attachment_image( $default_thumbnail_id, 'thumbnail' ); ?>
+										<?php
+										if ( count( $default_thumbnail_id ) > 1 ) {
+											?>
+											<a href="javascript:;" class="btn btn-outline-primary feedzy-images-selected">
+												<?php
+													// translators: %d select images count.
+													echo esc_html( sprintf( __( '(%d) images selected', 'feedzy-rss-feeds' ), count( $default_thumbnail_id ) ) );
+												?>
+											</a>
+											<?php
+										} else {
+											echo wp_get_attachment_image( reset( $default_thumbnail_id ), 'thumbnail' );
+										}
+										?>
 									</div>
 								<?php endif; ?>
 								<div class="fz-cta-group pb-8">
 									<a href="javascript:;" class="feedzy-open-media btn btn-outline-primary"><?php echo esc_html( $btn_label ); ?></a>
-									<a href="javascript:;" class="feedzy-remove-media btn btn-outline-primary <?php echo $default_thumbnail_id ? esc_attr( 'is-show' ) : ''; ?>"><?php esc_html_e( 'Remove', 'feedzy-rss-feeds' ); ?></a>
-									<input type="hidden" name="feedzy_meta_data[default_thumbnail_id]" id="feed-post-default-thumbnail" value="<?php echo esc_attr( $default_thumbnail_id ); ?>">
+									<a href="javascript:;" class="feedzy-remove-media btn btn-outline-primary <?php echo ! empty( $default_thumbnail_id ) ? esc_attr( 'is-show' ) : ''; ?>"><?php esc_html_e( 'Remove', 'feedzy-rss-feeds' ); ?></a>
+									<input type="hidden" name="feedzy_meta_data[default_thumbnail_id]" id="feed-post-default-thumbnail" value="<?php echo esc_attr( implode( ',', $default_thumbnail_id ) ); ?>">
 								</div>
 								<div class="help-text pt-8">
-									<?php esc_html_e( 'Helpful if you want to set a fallback image for feed items that don\'t have an image. Default it will be considered the one from global settings.', 'feedzy-rss-feeds' ); ?>
+									<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image. By default, the fallback image from the global settings will be used. If multiple fallback images are selected, one of them will be randomly assigned to each post without an image during the import process.', 'feedzy-rss-feeds' ); ?>
+									<br>
+									<strong><i><?php esc_html_e( 'By default, the fallback image from the global settings will be used.', 'feedzy-rss-feeds' ); ?><i></strong>
 								</div>
 							</div>
 						</div>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -693,7 +693,7 @@ global $post;
 									<input type="hidden" name="feedzy_meta_data[default_thumbnail_id]" id="feed-post-default-thumbnail" value="<?php echo esc_attr( implode( ',', $default_thumbnail_id ) ); ?>">
 								</div>
 								<div class="help-text pt-8">
-									<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image. By default, the fallback image from the global settings will be used. If multiple fallback images are selected, one of them will be randomly assigned to each post without an image during the import process.', 'feedzy-rss-feeds' ); ?>
+									<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image. If multiple fallback images are selected, one of them will be randomly assigned to each post without an image during the import process.', 'feedzy-rss-feeds' ); ?>
 								</div>
 							</div>
 						</div>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -694,8 +694,6 @@ global $post;
 								</div>
 								<div class="help-text pt-8">
 									<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image. By default, the fallback image from the global settings will be used. If multiple fallback images are selected, one of them will be randomly assigned to each post without an image during the import process.', 'feedzy-rss-feeds' ); ?>
-									<br>
-									<strong><i><?php esc_html_e( 'By default, the fallback image from the global settings will be used.', 'feedzy-rss-feeds' ); ?><i></strong>
 								</div>
 							</div>
 						</div>

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -928,23 +928,60 @@
 				button: {
 					text: feedzy.i10n.media_iframe_button
 				},
-				multiple: false
-		} ).on( 'select', function() { // it also has "open" and "close" events
-			var attachment = wp_media_uploader.state().get( 'selection' ).first().toJSON();
-			var attachmentUrl = attachment.url;
-			if ( attachment.sizes.thumbnail ) {
-				attachmentUrl = attachment.sizes.thumbnail.url;
-			}
-			if ( $( '.feedzy-media-preview' ).length ) {
-				$( '.feedzy-media-preview' ).find( 'img' ).attr( 'src', attachmentUrl );
-			} else {
-				$( '<div class="fz-form-group mb-20 feedzy-media-preview"><img src="' + attachmentUrl + '"></div>' ).insertBefore( button.parent() );
-			}
-			button.parent().find( '.feedzy-remove-media' ).addClass( 'is-show' );
-			button.parent().find( 'input:hidden' ).val( attachment.id ).trigger( 'change' );
-			$( '.feedzy-open-media' ).html( feedzy.i10n.action_btn_text_2 );
-		} ).open();
+				multiple: true
+			} ).on( 'select', function() { // it also has "open" and "close" events
+				var selectedAttachments = wp_media_uploader.state().get( 'selection' );
+				var countSelected = selectedAttachments?.toJSON()?.length;
+				button.parents( '.fz-form-group' ).find( '.feedzy-media-preview' ).remove();
+				// Display image preview when a single image is selected.
+				if ( 1 === countSelected ) {
+					var attachment = selectedAttachments.first().toJSON();
+					var attachmentUrl = attachment.url;
+					if ( attachment.sizes.thumbnail ) {
+						attachmentUrl = attachment.sizes.thumbnail.url;
+					}
+					if ( $( '.feedzy-media-preview' ).length ) {
+						$( '.feedzy-media-preview' ).find( 'img' ).attr( 'src', attachmentUrl );
+					} else {
+						$( '<div class="fz-form-group mb-20 feedzy-media-preview"><img src="' + attachmentUrl + '"></div>' ).insertBefore( button.parent() );
+					}
+				} else {
+					$( '<div class="fz-form-group mb-20 feedzy-media-preview"><a href="javascript:;" class="btn btn-outline-primary feedzy-images-selected">' + feedzy.i10n.action_btn_text_3.replace( '%d', countSelected ) + '</a></div>' ).insertBefore( button.parent() );
+				}
+				// Get all selected attachment ids.
+				var ids = selectedAttachments.map( function( attachment ) {
+					return attachment.id;
+				} ).join( ',' );
+
+				button.parent().find( '.feedzy-remove-media' ).addClass( 'is-show' );
+				button.parent().find( 'input:hidden' ).val( ids ).trigger( 'change' );
+				$( '.feedzy-open-media' ).html( feedzy.i10n.action_btn_text_2 );
+			} );
+
+			wp_media_uploader.on(' open', function() {
+				var selectedVal = button.parent().find( 'input:hidden' ).val();
+				if ( '' === selectedVal ) {
+					return;
+				}
+				var selection = wp_media_uploader.state().get('selection');
+
+				selectedVal.split(',').forEach(function( id ) {
+					var attachment = wp.media.attachment( id );
+					attachment.fetch();
+					selection.add(attachment ? [attachment] : []);
+				});
+			} );
+
+			wp_media_uploader.open();
 		});
+
+		$(document).on( 'click', '.feedzy-images-selected', function( e ) {
+			$(this)
+			.parents( '.fz-form-group' )
+			.find( '.feedzy-open-media' )
+			.trigger( 'click' );
+			e.preventDefault();
+		} );
 	}
 }(jQuery, feedzy));
 


### PR DESCRIPTION
### Summary
Added support for multiple fallback images, allowing users to choose several images that will be applied randomly to imported items.

### Will affect visual aspect of the product
Yes

### Screenshots
![image](https://github.com/user-attachments/assets/e2d1027b-43d8-4d57-a397-53fa63320063)

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/757
