### PR TITLE
Store error logs for each import job

### DIFF
--- a/css/feedzy-rss-feed-import.css
+++ b/css/feedzy-rss-feed-import.css
@@ -63,7 +63,7 @@
 .feedzy_page_feedzy-integration .feedzy-header{
 	margin-bottom: 40px;
 }
-.feedzy-api-error,
+
 .feedzy-error-critical {
 	color: #ff0000;
 }

--- a/feedzy-rss-feed.php
+++ b/feedzy-rss-feed.php
@@ -245,6 +245,30 @@ if ( FEEDZY_LOCAL_DEBUG ) {
 	}
 }
 
+/**
+ * Store import job errors in metadata.
+ *
+ * @param string $name Name.
+ * @param string $msg  Error message.
+ * @param string $type  Error type.
+ *
+ * @return void
+ */
+function feedzy_import_job_logs( $name, $msg, $type ) {
+	if ( ! in_array( $type, apply_filters( 'feedzy_allowed_store_log_types', array( 'error' ) ), true ) ) {
+		return;
+	}
+	if ( ! wp_doing_ajax() || wp_doing_cron() ) {
+		return;
+	}
+	if ( apply_filters( 'feedzy_skip_store_error_logs', false ) ) {
+		return;
+	}
+	global $themeisle_log_event;
+	$themeisle_log_event[] = $msg;
+}
+add_action( 'themeisle_log_event', 'feedzy_import_job_logs', 20, 3 );
+
 add_filter( 'themeisle_sdk_enable_telemetry', '__return_true' );
 
 add_filter(

--- a/feedzy-rss-feed.php
+++ b/feedzy-rss-feed.php
@@ -265,6 +265,11 @@ function feedzy_import_job_logs( $name, $msg, $type ) {
 		return;
 	}
 	global $themeisle_log_event;
+
+	if ( ! empty( $themeisle_log_event ) && count( $themeisle_log_event ) >= 200 ) {
+		return;
+	}
+
 	$themeisle_log_event[] = $msg;
 }
 add_action( 'themeisle_log_event', 'feedzy_import_job_logs', 20, 3 );

--- a/includes/views/css/import-metabox-edit.css
+++ b/includes/views/css/import-metabox-edit.css
@@ -131,3 +131,13 @@ span.feedzy-spinner {
 #TB_ajaxContent div.dry_run span i.fail {
 	color: #ca4a1f;
 }
+
+.feedzy-errors-dialog + .ui-widget-content .ui-dialog-buttonset {
+	width: 100%;
+}
+.feedzy-errors-dialog + .ui-widget-content button.feedzy-clear-logs {
+	margin-left: 0;
+}
+.feedzy-error.feedzy-api-error .notice-success {
+	color: #3c434a;
+}

--- a/includes/views/css/import-metabox-edit.css
+++ b/includes/views/css/import-metabox-edit.css
@@ -138,6 +138,3 @@ span.feedzy-spinner {
 .feedzy-errors-dialog + .ui-widget-content button.feedzy-clear-logs {
 	margin-left: 0;
 }
-.feedzy-error.feedzy-api-error .notice-success {
-	color: #3c434a;
-}

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -676,11 +676,59 @@
 				"ui-dialog-content": "feedzy-dialog-content",
 			},
 			width: 500,
-			buttons: {
-				Ok: function () {
-					$(this).dialog("close");
+			buttons:[
+				{
+					text: feedzy.i10n.okButton,
+					click: function () {
+						$(this).dialog('close');
+					}
+				}
+			]
+		});
+
+		// Error logs popup.
+		$(".feedzy-errors-dialog").dialog({
+			modal: true,
+			autoOpen: false,
+			height: 400,
+			width: 500,
+			buttons:[
+				{
+					text: feedzy.i10n.clearLogButton,
+					class: 'button button-primary feedzy-clear-logs',
+					click: function (event) {
+						var clearButton = $(event.target);
+						var dialogBox = $(this);
+						$('<span class="feedzy-spinner spinner is-active"></span>').insertAfter(clearButton);
+						clearButton.attr('disabled', true);
+						$.post(
+							ajaxurl,
+							{
+								security: feedzy.ajax.security,
+								id: $(this).attr('data-id'),
+								action: 'feedzy',
+								_action: 'clear_error_logs',
+							},
+							function () {
+								clearButton
+								.next('.feedzy-spinner')
+								.remove();
+
+								dialogBox
+								.find('.feedzy-error.feedzy-api-error')
+								.html('<div class="notice notice-success"><p>' + feedzy.i10n.removeErrorLogsMsg + '</p></div>')
+							}
+						);
+					}
 				},
-			},
+				{
+					text: feedzy.i10n.okButton,
+					class: 'alignright',
+					click: function () {
+						$(this).dialog('close');
+					}
+				}
+			]
 		});
 
 		$(".feedzy-dialog-open").on("click", function (e) {


### PR DESCRIPTION
### Summary
Adds error log storing features.

### Will affect visual aspect of the product
Yes

### Screenshots

![image](https://github.com/user-attachments/assets/72a93d88-6aea-4936-a9d9-c995843a4b14)

### Test instructions

Option 1:
Activate a lower license plan and use higher plan magic tags in the import job.

Option 2:
Add the following code snippet to allow other error types:

```
add_filter(
	'feedzy_allowed_store_log_types',
	function ( $types ) {
		$types[] = 'debug'; // info, warn
		return $types;
	}
);
```

Users can disable the error storing feature by adding the following code snippet:

```
add_filter( 'feedzy_skip_store_error_logs', '__return_true' );
```

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/701
