### PR TITLE
Move license key section

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -2466,3 +2466,31 @@ li.draggable-item .components-panel__body-toggle.components-button{
 .fz-prompt-button button.components-button {
 	height: 28px;
 }
+.fz-license-section button#check_ti_license:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+.fz-license-section button#check_ti_license .dashicons-update {
+	display: none;
+}
+.fz-license-section button#check_ti_license.fz-checking .dashicons-update {
+	-webkit-animation:spin 2s linear infinite;
+    -moz-animation:spin 2s linear infinite;
+    animation:spin 2s linear infinite;
+    display: inline-block;
+}
+.fz-license-section .help-text:has(.dashicons-dismiss) {
+	color: #F00;
+}
+.fz-license-section .help-text:has(.dashicons-yes) {
+	color: #6eb77a;
+}
+@-webkit-keyframes spin { 
+    100% { -webkit-transform: rotate(360deg); } 
+}
+@keyframes spin { 
+    100% { 
+        -webkit-transform: rotate(360deg); 
+        transform:rotate(360deg); 
+    } 
+}

--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -114,6 +114,7 @@
 						case 'general':
 							?>
 							<div class="fz-form-wrap">
+								<?php do_action( 'feedzy_general_setting_before' ); ?>	
 								<div class="form-block">
 									<div class="fz-form-group">
 										<label for="feed-post-default-thumbnail" class="form-label"><?php echo esc_html_e( 'Fallback image for imported posts', 'feedzy-rss-feeds' ); ?></label>

--- a/js/feedzy-setting.js
+++ b/js/feedzy-setting.js
@@ -64,7 +64,7 @@ jQuery( function( $ ) {
   $( ':input' ).change(function () {         
     unsaved = true;
   });
-  $( '#feedzy-settings-submit, #check_wordai_api, #check_spinnerchief_api, #check_aws_api, #check_openai_api, #check_openrouter_api' ).on( 'click', function() {
+  $( '#feedzy-settings-submit, #check_wordai_api, #check_spinnerchief_api, #check_aws_api, #check_openai_api, #check_openrouter_api, #check_ti_license' ).on( 'click', function() {
     unsaved = false;
   } );
   window.addEventListener( 'beforeunload', function( e ) {
@@ -78,5 +78,48 @@ jQuery( function( $ ) {
   $( document ).on( 'change', '#fz-event-execution', function() {
       $( '#fz-execution-offset' ).val( new Date().getTimezoneOffset() / 60 );
   } );
+
+  // License key.
+  jQuery('.fz-license-section #license_key').on( 'input', function() {
+    var licenseKey = jQuery(this).val();
+    if ( licenseKey !== '' ) {
+      jQuery( '#check_ti_license' ).removeAttr( 'disabled' );
+    } else {
+      jQuery( '#check_ti_license' ).attr( 'disabled', true );
+    }
+    jQuery('.fz-license-section input[name="license_key"]').val( licenseKey );
+  } );
+
+  jQuery('.fz-license-section #check_ti_license').on('click', function (e) {
+    e.preventDefault();
+    var _this = jQuery(this);
+    _this
+    .attr('disabled', true)
+    .addClass( 'fz-checking' );
+
+    _this
+    .parents( '.fz-license-section' )
+    .find( '.feedzy-api-error' )
+    .remove();
+
+    const LicenseData = _this
+    .parent( '.fz-input-group-btn' )
+    .find( 'input' )
+    .serialize();
+
+    jQuery.post( ajaxurl, LicenseData,
+      function (response) {
+        if ( ! response.success ) {
+          jQuery( '<p class="feedzy-api-error">' + response.message + '</p>' ).insertAfter( jQuery( '.fz-license-section' ).find( '.help-text' ) );
+          _this
+          .removeAttr('disabled')
+          .removeClass( 'fz-checking' );
+        } else {
+          window.location.reload();
+        }
+      },
+      'json'
+    );
+  });
   snackbarNotice();
 });


### PR DESCRIPTION
### Summary
I've moved the license key section into feedzy general settings page.

### Will affect visual aspect of the product
Yes

### Screenshots
![image](https://github.com/user-attachments/assets/58ddc487-9765-406c-87d7-03b78d07402a)

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/805
