### PR TITLE
fix: Feedzy Loop button not working with Groups

### DIFF
--- a/js/FeedzyLoop/components/FeedControl.js
+++ b/js/FeedzyLoop/components/FeedControl.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies.
  */
+import { __ } from '@wordpress/i18n';
+
 import { useState, useEffect, useRef } from '@wordpress/element';
 
 const FeedControl = ({ value, options, onChange }) => {
@@ -80,7 +82,10 @@ const FeedControl = ({ value, options, onChange }) => {
 				value={selectedOption ? selectedOption.label : inputValue}
 				onChange={handleInputChange}
 				onBlur={handleInputBlur}
-				placeholder="Enter URLs or select a category"
+				placeholder={__(
+					'Enter URLs or select a Feed Group',
+					'feedzy-rss-feeds'
+				)}
 				disabled={selectedOption !== null}
 				className="fz-input-field"
 			/>
@@ -89,7 +94,7 @@ const FeedControl = ({ value, options, onChange }) => {
 					<button
 						onClick={handleClear}
 						className="fz-clear-button"
-						title="Clear selection"
+						title={__('Clear', 'feedzy-rss-feeds')}
 					>
 						<svg
 							width="14"
@@ -111,6 +116,7 @@ const FeedControl = ({ value, options, onChange }) => {
 				<button
 					onClick={() => setIsOpen(!isOpen)}
 					className="fz-dropdown-button"
+					title={__('Select Feed Group', 'feedzy-rss-feeds')}
 				>
 					<svg
 						width="12"

--- a/js/FeedzyLoop/placeholder.js
+++ b/js/FeedzyLoop/placeholder.js
@@ -82,10 +82,7 @@ const BlockPlaceholder = ({ attributes, setAttributes, onSaveFeed }) => {
 						<Button
 							variant="primary"
 							onClick={() => {
-								if (
-									attributes?.feed?.source &&
-									attributes?.feed?.source.length > 0
-								) {
+								if (attributes?.feed?.source) {
 									onSaveFeed();
 								}
 							}}

--- a/tests/e2e/specs/loop.spec.js
+++ b/tests/e2e/specs/loop.spec.js
@@ -9,6 +9,17 @@ test.describe('Feedzy Loop', () => {
 	const POST_TITLE = `Feedzy Loop Test ${Math.floor(Math.random() * 1000)}`;
 
 	test('add Feedzy Loop Block', async ({ editor, page }) => {
+		await page.goto('/wp-admin/post-new.php?post_type=feedzy_categories');
+		await page.getByLabel('Add title').click();
+		await page.keyboard.type('Group One');
+
+		await page.locator('textarea[name="feedzy_category_feed"]').click();
+		await page.keyboard.type(FEED_URL);
+		await page
+			.getByRole('button', { name: 'Publish', exact: true })
+			.click();
+		await page.waitForTimeout(1000);
+
 		await page.goto('/wp-admin/post-new.php');
 
 		if (
@@ -36,12 +47,34 @@ test.describe('Feedzy Loop', () => {
 		await page.getByPlaceholder('Enter URLs or select a').click();
 		await page.keyboard.type(FEED_URL);
 
+		const loadFeedButton = await page.getByRole('button', {
+			name: 'Load Feed',
+			exact: true,
+		});
+		const isDisabled = await loadFeedButton.isDisabled();
+		expect(isDisabled).toBe(false);
+		await loadFeedButton.click();
+		await page.waitForTimeout(1000);
+
+		await page.getByLabel('Display curated RSS content').click();
+		await page.waitForTimeout(1000);
+
+		// Now that we have tested we can insert URL, we can test the Feed Group.
+
+		await page
+			.getByLabel('Block: Feedzy Loop')
+			.locator('div')
+			.nth(1)
+			.click();
+		await page.getByRole('button', { name: 'Edit Feed' }).click();
+
+		await page.getByRole('button', { name: 'Select Feed Group' }).click();
+		await page.locator('.fz-dropdown-item').first().click();
+
 		await page
 			.getByRole('button', { name: 'Load Feed', exact: true })
 			.click();
 		await page.waitForTimeout(1000);
-
-		await page.getByLabel('Display curated RSS content').click();
 
 		await page
 			.getByRole('button', { name: 'Publish', exact: true })


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixes the issue with Loop Block's load feed button not working with Feed Groups.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the Loop works with both groups and URL.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/816.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
