### PR TITLE
fix: use module import for deps in Block

### DIFF
--- a/js/FeedzyBlock/Editor.js
+++ b/js/FeedzyBlock/Editor.js
@@ -1,17 +1,19 @@
 /**
  * WordPress dependencies
  */
-const { __, sprintf } = wp.i18n;
-
-const { apiRequest } = wp;
-
-const { Component, Fragment } = wp.element;
-
-const { ExternalLink, Placeholder, TextControl, Button, Spinner } =
-	wp.components;
+import {
+	ExternalLink,
+	Placeholder,
+	TextControl,
+	Button,
+	Spinner,
+} from '@wordpress/components';
 
 import queryString from 'query-string';
 import Inspector from './inspector';
+import { __, sprintf } from '@wordpress/i18n';
+import { apiFetch as apiRequest } from '@wordpress/api-fetch';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	unescapeHTML,
 	filterData,

--- a/js/FeedzyBlock/index.js
+++ b/js/FeedzyBlock/index.js
@@ -1,4 +1,6 @@
 // jshint ignore: start
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Block dependencies
@@ -6,13 +8,6 @@
 import './style.scss';
 import blockAttributes from './attributes.js';
 import Editor from './Editor.js';
-
-/**
- * Internal block libraries
- */
-const { __ } = wp.i18n;
-
-const { registerBlockType } = wp.blocks;
 
 /**
  * Register block

--- a/js/FeedzyBlock/inspector.js
+++ b/js/FeedzyBlock/inspector.js
@@ -3,26 +3,17 @@
 /**
  * Block dependencies
  */
-import { RawHTML } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import RadioImageControl from './radio-image-control/';
 
 /**
  * External dependencies
  */
 import classnames from 'classnames';
-
-/**
- * Internal block libraries
- */
-const { __ } = wp.i18n;
-
-const { applyFilters } = wp.hooks;
-
-const { InspectorControls, MediaUpload } = wp.blockEditor || wp.editor;
-
-const { Component, Fragment } = wp.element;
-
-const {
+import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
+import { InspectorControls, MediaUpload } from '@wordpress/block-editor';
+import {
 	BaseControl,
 	ExternalLink,
 	PanelBody,
@@ -34,7 +25,7 @@ const {
 	SelectControl,
 	ResponsiveWrapper,
 	Dashicon,
-} = wp.components;
+} from '@wordpress/components';
 
 /**
  * Create an Inspector Controls wrapper Component

--- a/js/FeedzyBlock/radio-image-control/index.js
+++ b/js/FeedzyBlock/radio-image-control/index.js
@@ -4,50 +4,63 @@
  * Block dependencies
  */
 import './style.scss';
+import { isEmpty } from 'lodash';
+import { BaseControl } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
 
-/**
- * Internal dependencies
- */
-const { isEmpty } = lodash;
+function RadioImageControl({
+	label,
+	selected,
+	help,
+	instanceId,
+	onChange,
+	disabled,
+	options = [],
+}) {
+	const id = `inspector-radio-image-control-${instanceId}`;
+	const onChangeValue = (event) => onChange(event.target.value);
 
-const { BaseControl } = wp.components;
-
-const { withInstanceId } = wp.compose;
-
-
-function RadioImageControl( { label, selected, help, instanceId, onChange, disabled, options = [] } ) {
-	const id = `inspector-radio-image-control-${ instanceId }`;
-	const onChangeValue = ( event ) => onChange( event.target.value );
-
-	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id } help={ help } className="components-radio-image-control feedzy-template">
-			<div className="components-radio-image-control__container">
-				{ options.map( ( option, index ) =>
-					<div
-						key={ `${ id }-${ index }` }
-						className="components-radio-image-control__option"
-					>
-						<input
-							id={ `${ id }-${ index }` }
-							className="components-radio-image-control__input"
-							type="radio"
-							name={ id }
-							value={ option.value }
-							onChange={ onChangeValue }
-							checked={ option.value === selected }
-							aria-describedby={ !! help ? `${ id }__help` : undefined }
-							disabled={ disabled }
-						/>
-						<label htmlFor={ `${ id }-${ index }` } title={ option.label }>
-							<img src={ option.src } />
-							<span class="image-clickable"></span>
-						</label>
-						<span>{ option.label }</span>
-					</div>
-				) }
-			</div>
-		</BaseControl>
+	return (
+		!isEmpty(options) && (
+			<BaseControl
+				label={label}
+				id={id}
+				help={help}
+				className="components-radio-image-control feedzy-template"
+			>
+				<div className="components-radio-image-control__container">
+					{options.map((option, index) => (
+						<div
+							key={`${id}-${index}`}
+							className="components-radio-image-control__option"
+						>
+							<input
+								id={`${id}-${index}`}
+								className="components-radio-image-control__input"
+								type="radio"
+								name={id}
+								value={option.value}
+								onChange={onChangeValue}
+								checked={option.value === selected}
+								aria-describedby={
+									!!help ? `${id}__help` : undefined
+								}
+								disabled={disabled}
+							/>
+							<label
+								htmlFor={`${id}-${index}`}
+								title={option.label}
+							>
+								<img src={option.src} />
+								<span className="image-clickable"></span>
+							</label>
+							<span>{option.label}</span>
+						</div>
+					))}
+				</div>
+			</BaseControl>
+		)
 	);
 }
 
-export default withInstanceId( RadioImageControl );
+export default withInstanceId(RadioImageControl);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Using the global variable for dependencies works but the build files can not be properly scanned by WordPress i18n functions.

I switched to import from `package.json`, like the rest of the scripts.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if there is a regression with the build file.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/978
<!-- Should look like this: `Closes #1, #2, #3.` . -->
