### PR TITLE
fixed: settings layout

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -2570,3 +2570,16 @@ li.draggable-item .components-panel__body-toggle.components-button{
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
+
+.fz-proxy-info-box {
+    margin-top: 30px;
+}
+
+.fz-section-title {
+    margin: 0 0 15px 0;
+}
+
+.fz-section-description p {
+    margin: 0 0 10px 0;
+    line-height: 1.6;
+}

--- a/css/settings.css
+++ b/css/settings.css
@@ -531,7 +531,7 @@ fieldset[disabled] .form-control {
 	content: "";
 	width: 24px;
 	height: 24px;
-	background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18 18L14 14.5' stroke='%23757575' stroke-width='1.5'/%3E%3Ccircle r='4.75' transform='matrix(-1 0 0 1 10.5 11.5)' stroke='%23757575' stroke-width='1.5'/%3E%3C/svg%3E%0A");
+	background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18 18L14 14.5' stroke='%23757575' stroke-width='1.5'/%3E%3Ccircle r='4.75' transform='matrix(-1 0 0 1 10.5 11.5)' stroke='%23757575' stroke-width='1.5'/%3E%3C/svg%3E");
 	background-repeat: no-repeat;
 	position: absolute;
 	left: 16px;
@@ -1530,7 +1530,7 @@ input.fz-switch-toggle[type=checkbox]:checked:before{
 }
 
 .post-type-feedzy_categories #titlediv #title:focus,
-.post-type-feedzy_categories .widefat:focus{
+.post-type_feedzy_categories .widefat:focus{
 	border-color: #4268CF;
 }
 .fz-upsell-notice {
@@ -2582,4 +2582,11 @@ li.draggable-item .components-panel__body-toggle.components-button{
 .fz-section-description p {
     margin: 0 0 10px 0;
     line-height: 1.6;
+}
+
+.fz-form-actions {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 15px;
 }

--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -387,7 +387,10 @@
 						?>
 						<div class="mb-24 fz-form-actions">
 							<button type="submit" class="btn btn-primary<?php echo esc_attr( $disable_button ); ?>" id="feedzy-settings-submit" name="feedzy-settings-submit"><?php esc_html_e( 'Save Settings', 'feedzy-rss-feeds' ); ?></button>
-							<a href="<?php echo esc_url( $help_btn_url ); ?>" class="btn btn-ghost" target="_blank"><?php esc_html_e( 'Go to Documentation', 'feedzy-rss-feeds' ); ?></a>
+							<a href="<?php echo esc_url( $help_btn_url ); ?>" class="btn btn-ghost" target="_blank">
+								<?php esc_html_e( 'Go to Documentation', 'feedzy-rss-feeds' ); ?>
+								<span class="dashicons dashicons-external"></span>
+							</a>
 						</div>
 						
 						<?php

--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -54,12 +54,6 @@
 							case 'misc':
 								esc_html_e( 'Miscellaneous', 'feedzy-rss-feeds' );
 								break;
-							case 'spinnerchief':
-								esc_html_e( 'SpinnerChief', 'feedzy-rss-feeds' );
-								break;
-							case 'wordai':
-								esc_html_e( 'WordAI', 'feedzy-rss-feeds' );
-								break;
 							default:
 								echo esc_html( ucwords( str_replace( array( '-', '_' ), ' ', $active_tab ) ) );
 								break;
@@ -278,16 +272,30 @@
 						case 'headers':
 							?>
 							<div class="fz-form-wrap">
-								<div class="form-block">
-									<div class="fz-form-group">
-										<label class="form-label"><?php esc_html_e( 'User Agent', 'feedzy-rss-feeds' ); ?></label>
-										<input
-											type="text"
-											class="form-control"
-											name="user-agent"
-											placeholder="<?php esc_attr_e( 'Add the user agent string', 'feedzy-rss-feeds' ); ?>"
-											value="<?php echo isset( $settings['header']['user-agent'] ) ? esc_attr( $settings['header']['user-agent'] ) : ''; ?>"
-										>
+								<div class="fz-proxy-info-box">
+									<h3 class="fz-section-title"><?php esc_html_e( 'HTTP Headers Configuration', 'feedzy-rss-feeds' ); ?></h3>
+									<div class="fz-section-description">
+										<p><?php esc_html_e( 'Customize the HTTP headers sent when fetching RSS feeds. This can help bypass certain restrictions or identify your requests to feed providers.', 'feedzy-rss-feeds' ); ?></p>
+										<p class="fz-when-to-use">
+											<?php esc_html_e( 'Configure a custom user agent if feeds are blocking default WordPress requests or require specific identification.', 'feedzy-rss-feeds' ); ?>
+										</p>
+									</div>
+								</div>
+								
+								<div class="form-block pb-0">
+									<div class="fz-form-row">
+										<div class="fz-form-col-4">
+											<div class="fz-form-group">
+												<label class="form-label"><?php esc_html_e( 'User Agent', 'feedzy-rss-feeds' ); ?></label>
+												<input
+													type="text"
+													class="form-control"
+													name="user-agent"
+													placeholder="<?php esc_attr_e( 'Add the user agent string', 'feedzy-rss-feeds' ); ?>"
+													value="<?php echo isset( $settings['header']['user-agent'] ) ? esc_attr( $settings['header']['user-agent'] ) : ''; ?>"
+												>
+											</div>
+										</div>
 									</div>
 								</div>
 							</div>
@@ -296,43 +304,55 @@
 						case 'proxy':
 							?>
 							<div class="fz-form-wrap">
+								<div class="fz-proxy-info-box">
+									<h3 class="fz-section-title"><?php esc_html_e( 'Proxy Configuration', 'feedzy-rss-feeds' ); ?></h3>
+									<div class="fz-section-description">
+										<p><?php esc_html_e( 'Use these settings if you need to fetch RSS feeds through a proxy server. This is commonly required in corporate environments or when your hosting provider restricts direct internet access.', 'feedzy-rss-feeds' ); ?></p>
+										<p class="fz-when-to-use">
+											<?php esc_html_e( 'Only configure these settings if you know you need a proxy. Leave empty for direct connections.', 'feedzy-rss-feeds' ); ?>
+										</p>
+									</div>
+								</div>
 								<div class="form-block pb-0">
 									<div class="fz-form-row">
 										<div class="fz-form-col-6">
 											<div class="fz-form-group">
-												<label class="form-label"><?php esc_html_e( 'Username', 'feedzy-rss-feeds' ); ?>:</label>
+												<label class="form-label"><?php esc_html_e( 'Username', 'feedzy-rss-feeds' ); ?></label>
 												<input type="text" class="form-control" name="proxy-user" placeholder="<?php esc_attr_e( 'Enter the authorized username', 'feedzy-rss-feeds' ); ?>"
 													value="<?php echo isset( $settings['proxy']['user'] ) ? esc_attr( $settings['proxy']['user'] ) : ''; ?>">
 											</div>
 										</div>
 										<div class="fz-form-col-6">
 											<div class="fz-form-group">
-												<label class="form-label"><?php esc_html_e( 'Password', 'feedzy-rss-feeds' ); ?>:</label>
+												<label class="form-label"><?php esc_html_e( 'Password', 'feedzy-rss-feeds' ); ?></label>
 												<input type="password" class="form-control" name="proxy-pass" placeholder="<?php esc_attr_e( 'Enter the password for the authorized user', 'feedzy-rss-feeds' ); ?>"
 													value="<?php echo isset( $settings['proxy']['pass'] ) ? esc_attr( $settings['proxy']['pass'] ) : ''; ?>">
 											</div>
 										</div>
 										<div class="fz-form-col-8">
 											<div class="fz-form-group">
-												<label class="form-label"><?php esc_html_e( 'Host', 'feedzy-rss-feeds' ); ?>:</label>
+												<label class="form-label"><?php esc_html_e( 'Host', 'feedzy-rss-feeds' ); ?></label>
 												<input type="text" class="form-control" name="proxy-host" placeholder="<?php esc_attr_e( 'Enter the IP address or Domain name of the proxy server', 'feedzy-rss-feeds' ); ?>"
 													value="<?php echo isset( $settings['proxy']['host'] ) ? esc_attr( $settings['proxy']['host'] ) : ''; ?>">
 												<div class="help-text pt-8">
 													<?php
-													/* translators: %s: the value to introduce. */
-													printf( esc_html__( 'Example: %s', 'feedzy-rss-feeds' ), '127.0.0.1' );
+														printf(
+															// translators: %s is the example value.
+															esc_html__( 'Example: %s', 'feedzy-rss-feeds' ),
+															esc_html( '192.168.1.100, proxy.mycompany.com' )
+														);
 													?>
 												</div>
 											</div>
 										</div>
 										<div class="fz-form-col-4">
 											<div class="fz-form-group">
-												<label class="form-label"><?php esc_html_e( 'Port', 'feedzy-rss-feeds' ); ?>:</label>
+												<label class="form-label"><?php esc_html_e( 'Port', 'feedzy-rss-feeds' ); ?></label>
 												<input type="number" min="0" max="65535" class="form-control" name="proxy-port" placeholder="<?php esc_attr_e( 'Add the port number', 'feedzy-rss-feeds' ); ?>"
 													value="<?php echo isset( $settings['proxy']['port'] ) ? esc_attr( (int) $settings['proxy']['port'] ) : ''; ?>">
 												<div class="help-text pt-8">
 													<?php
-													/* translators: %s: the value to introduce. */
+													// translators: %s is the example value.
 													printf( esc_html__( 'Example: %s', 'feedzy-rss-feeds' ), '8080' );
 													?>
 												</div>
@@ -365,19 +385,17 @@
 					if ( $show_button ) {
 							$disable_button = ! feedzy_is_pro() && in_array( $active_tab, array( 'spinnerchief', 'wordai', 'amazon-product-advertising', 'openai' ), true ) ? ' disabled' : '';
 						?>
-						<div class="mb-24">
+						<div class="mb-24" style="display: flex; justify-content: space-between; align-items: center; gap: 15px;">
 							<button type="submit" class="btn btn-primary<?php echo esc_attr( $disable_button ); ?>" id="feedzy-settings-submit" name="feedzy-settings-submit"><?php esc_html_e( 'Save Settings', 'feedzy-rss-feeds' ); ?></button>
+							<a href="<?php echo esc_url( $help_btn_url ); ?>" class="btn btn-ghost" target="_blank"><?php esc_html_e( 'Go to Documentation', 'feedzy-rss-feeds' ); ?></a>
 						</div>
+						
 						<?php
 					}
 					?>
 				</form>
 
 			</div>
-		</div>
-
-		<div class="cta pt-30">
-			<a href="<?php echo esc_url( $help_btn_url ); ?>" class="btn btn-ghost" target="_blank"><?php esc_html_e( 'Need help?', 'feedzy-rss-feeds' ); ?></a>
 		</div>
 	</div>
 </div>

--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -385,7 +385,7 @@
 					if ( $show_button ) {
 							$disable_button = ! feedzy_is_pro() && in_array( $active_tab, array( 'amazon-product-advertising', 'openai' ), true ) ? ' disabled' : '';
 						?>
-						<div class="mb-24" style="display: flex; justify-content: space-between; align-items: center; gap: 15px;">
+						<div class="mb-24 fz-form-actions">
 							<button type="submit" class="btn btn-primary<?php echo esc_attr( $disable_button ); ?>" id="feedzy-settings-submit" name="feedzy-settings-submit"><?php esc_html_e( 'Save Settings', 'feedzy-rss-feeds' ); ?></button>
 							<a href="<?php echo esc_url( $help_btn_url ); ?>" class="btn btn-ghost" target="_blank"><?php esc_html_e( 'Go to Documentation', 'feedzy-rss-feeds' ); ?></a>
 						</div>

--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -383,7 +383,7 @@
 					<?php
 					wp_nonce_field( $active_tab, 'nonce' );
 					if ( $show_button ) {
-							$disable_button = ! feedzy_is_pro() && in_array( $active_tab, array( 'spinnerchief', 'wordai', 'amazon-product-advertising', 'openai' ), true ) ? ' disabled' : '';
+							$disable_button = ! feedzy_is_pro() && in_array( $active_tab, array( 'amazon-product-advertising', 'openai' ), true ) ? ' disabled' : '';
 						?>
 						<div class="mb-24" style="display: flex; justify-content: space-between; align-items: center; gap: 15px;">
 							<button type="submit" class="btn btn-primary<?php echo esc_attr( $disable_button ); ?>" id="feedzy-settings-submit" name="feedzy-settings-submit"><?php esc_html_e( 'Save Settings', 'feedzy-rss-feeds' ); ?></button>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Refactors the settings menu to group HTTP headers and proxy configurations with descriptive info boxes, updates the Save Settings area to include a documentation link, and removes obsolete SpinnerChief/WordAI tabs.
### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="2444" height="1712" alt="CleanShot 2025-07-15 at 16 33 47@2x" src="https://github.com/user-attachments/assets/62a5eccd-6b62-4d36-9df5-f8eed248da90" />
<img width="2408" height="958" alt="CleanShot 2025-07-15 at 16 35 05@2x" src="https://github.com/user-attachments/assets/35c0b08d-4090-4ec1-8fdb-21e3c17ad975" />
<img width="2426" height="1276" alt="CleanShot 2025-07-15 at 16 35 15@2x" src="https://github.com/user-attachments/assets/ecaa1a79-a5f4-406a-a359-663111a19867" />



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Navigate thourgh the settings menu.


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/871
<!-- Should look like this: `Closes #1, #2, #3.` . -->
