### PR TITLE
feat: add optgroup label support in feed options

### DIFF
--- a/includes/feedzy-rss-feeds-feed-tweaks.php
+++ b/includes/feedzy-rss-feeds-feed-tweaks.php
@@ -446,7 +446,8 @@ add_filter(
 				'selected' => array(),
 			),
 			'optgroup' => array(
-				'label' => array(),
+				'label'    => array(),
+				'disabled' => array(),
 			),
 			'input'    => array(
 				'type'        => array(),


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Add optgroup label support in feed options.

Part of https://github.com/Codeinwp/feedzy-rss-feeds-pro/pull/917
### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/878
<!-- Should look like this: `Closes #1, #2, #3.` . -->
