### PR TITLE
dev: track the import count per week and days since install

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -156,10 +156,11 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		$shortcodes = $wpdb->get_var( "SELECT count(*) FROM {$wpdb->prefix}posts WHERE post_status IN ('publish', 'private') AND post_content LIKE '%[feedzy-rss %'" ); //phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		$data = array(
-			'categories' => $categories,
-			'imports'    => $imports,
-			'shortcodes' => $shortcodes,
-			'license'    => $license,
+			'categories'         => $categories,
+			'imports'            => $imports,
+			'shortcodes'         => $shortcodes,
+			'license'            => $license,
+			'days_since_install' => round( ( time() - get_option( 'feedzy_rss_feeds_install', time() ) ) / DAY_IN_SECONDS ),
 		);
 
 		$settings = apply_filters( 'feedzy_get_settings', null );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Add the import run count per week for telemetry with the format:

```php
'imports_per_week' => 
  array (
    0 => 
    array (
      'year' => 2025,
      'week' => 30,
      'month' => 7,
      'count' => 2,
  )
)
```
- Add the days since install for temeletry

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- No crashes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
