### PR TITLE
Fixed fallback image in classic block

### DIFF
--- a/js/FeedzyBlock/Editor.js
+++ b/js/FeedzyBlock/Editor.js
@@ -222,7 +222,7 @@ class Editor extends Component {
 	}
 
 	getImageURL(item, background) {
-		let url = item.thumbnail
+		let url = item.thumbnail && this.props.attributes.thumb === 'auto'
 			? item.thumbnail
 			: this.props.attributes.default
 				? this.props.attributes.default.url


### PR DESCRIPTION
### Summary
Fixed the fallback image when the first image with the fallback image option is selected.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/910