### PR TITLE
fix: image handling in Feedzy RSS Feeds

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1628,7 +1628,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		$image_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'tiff', 'tif' );
-		$url_parts        = parse_url( $url );
+		$url_parts        = wp_parse_url( $url );
 		if ( ! isset( $url_parts['path'] ) ) {
 			return false;
 		}
@@ -1687,10 +1687,10 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 					}
 				}
 
-				$embeded_thumbnail = $enclosure->embed();
-				if ( $embeded_thumbnail ) {
+				$embedded_thumbnail = $enclosure->embed();
+				if ( $embedded_thumbnail ) {
 					$pattern = '/https?:\/\/.*\.(?:jpg|JPG|jpeg|JPEG|jpe|JPE|gif|GIF|png|PNG)/i';
-					if ( preg_match( $pattern, $embeded_thumbnail, $matches ) ) {
+					if ( preg_match( $pattern, $embedded_thumbnail, $matches ) ) {
 						$the_thumbnail = $matches[0];
 					}
 				}

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1627,7 +1627,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			return false;
 		}
 
-		$image_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'tiff', 'tif' );
+		$image_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'tiff', 'tif', 'avif' );
 		$url_parts        = wp_parse_url( $url );
 		if ( ! isset( $url_parts['path'] ) ) {
 			return false;

--- a/includes/util/feedzy-rss-feeds-conditions.php
+++ b/includes/util/feedzy-rss-feeds-conditions.php
@@ -240,7 +240,7 @@ class Feedzy_Rss_Feeds_Conditions {
 	 *
 	 * @param bool                  $default_value The current return value.
 	 * @param array<string, string> $attrs The attributes of the feed.
-	 * @param array<string, string> $item The item to evaluate.
+	 * @param SimplePie\Item        $item The item to evaluate.
 	 * @param string                $feed_url The URL of the feed.
 	 * @param int                   $index The index of the item.
 	 *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1706,42 +1706,12 @@ parameters:
 			path: includes/layouts/setup-wizard.php
 
 		-
-			message: "#^Cannot call method get_author\\(\\) on array\\<string, string\\>\\.$#"
-			count: 1
-			path: includes/util/feedzy-rss-feeds-conditions.php
-
-		-
-			message: "#^Cannot call method get_content\\(\\) on array\\<string, string\\>\\.$#"
-			count: 1
-			path: includes/util/feedzy-rss-feeds-conditions.php
-
-		-
-			message: "#^Cannot call method get_date\\(\\) on array\\<string, string\\>\\.$#"
-			count: 1
-			path: includes/util/feedzy-rss-feeds-conditions.php
-
-		-
-			message: "#^Cannot call method get_item_tags\\(\\) on array\\<string, string\\>\\.$#"
-			count: 1
-			path: includes/util/feedzy-rss-feeds-conditions.php
-
-		-
-			message: "#^Cannot call method get_title\\(\\) on array\\<string, string\\>\\.$#"
-			count: 1
-			path: includes/util/feedzy-rss-feeds-conditions.php
-
-		-
 			message: "#^Constant SIMPLEPIE_NAMESPACE_ATOM_10 not found\\.$#"
 			count: 1
 			path: includes/util/feedzy-rss-feeds-conditions.php
 
 		-
 			message: "#^Method Feedzy_Rss_Feeds_Conditions\\:\\:migrate_conditions\\(\\) has parameter \\$conditions with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: includes/util/feedzy-rss-feeds-conditions.php
-
-		-
-			message: "#^Parameter \\#1 \\$item of method Feedzy_Rss_Feeds_Admin_Abstract\\:\\:feedzy_retrieve_image\\(\\) expects object, array\\<string, string\\> given\\.$#"
 			count: 1
 			path: includes/util/feedzy-rss-feeds-conditions.php
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Treated invalid thumbnails that don't respect the image format.
Reduce the number of phpstan errors.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
#### Clasic and Loop
<img width="4462" height="1466" alt="CleanShot 2025-07-28 at 17 44 22@2x" src="https://github.com/user-attachments/assets/92c69957-c3b8-4f11-85ba-9c21a3959cc0" />

#### Importer
<img width="3600" height="566" alt="CleanShot 2025-07-28 at 17 44 42@2x" src="https://github.com/user-attachments/assets/d4ac3c24-051e-46cc-8430-6a310735c1b5" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Try to fetch an url without a valid image url like: https://wpshout.com/feed/

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/867
<!-- Should look like this: `Closes #1, #2, #3.` . -->
