### PR TITLE
Improved feed group UX

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -2620,6 +2620,29 @@ li.draggable-item .components-panel__body-toggle.components-button{
 	color: #050505;
 }
 
+.validate-feeds-actions {
+	display: flex;;
+}
+.validate-feeds-actions .spinner:not(.is-active) {
+	display: none;
+}
+.validate-feeds-actions .spinner.is-active {
+	display: inline-block;
+}
+.feedzy-preview-list {
+	padding-left: 15px;
+}
+.feedzy-preview-list li {
+	list-style: disc;
+}
+.feedzy-preview-list li a {
+	text-decoration: none;
+}
+.feedzy-preview-list li time {
+	font-size: 11px;
+	font-weight: 500;
+	color: #757575;
+}
 @-webkit-keyframes spin { 
     100% { -webkit-transform: rotate(360deg); } 
 }

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1962,10 +1962,10 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 */
 	public function feedzy_image_encode( $img_url ) {
 		// Check if img url is set as an URL parameter.
-		$parsed_url = wp_parse_url( $img_url );
-		if ( isset( $parsed_url['query'] ) ) {
-			preg_match_all( '/(http|https):\/\/[^ ]+(\.(gif|jpg|jpeg|png|webp|avif))/i', $parsed_url['query'], $matches );
-			if ( isset( $matches[0][0] ) && $this->is_image_url( $matches[0][0] ) ) {
+		$url_tab = wp_parse_url( $img_url );
+		if ( isset( $url_tab['query'] ) ) {
+			preg_match_all( '/(http|https):\/\/[^ ]+(\.gif|\.GIF|\.jpg|\.JPG|\.jpeg|\.JPEG|\.png|\.PNG)/', $url_tab['query'], $matches );
+			if ( isset( $matches[0][0] ) ) {
 				$img_url = $matches[0][0];
 			}
 		}

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1964,7 +1964,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		// Check if img url is set as an URL parameter.
 		$url_tab = wp_parse_url( $img_url );
 		if ( isset( $url_tab['query'] ) ) {
-			preg_match_all( '/(http|https):\/\/[^ ]+(\.gif|\.GIF|\.jpg|\.JPG|\.jpeg|\.JPEG|\.png|\.PNG)/', $url_tab['query'], $matches );
+			preg_match_all( '/(http|https):\/\/[^ ]+(\.gif|\.GIF|\.jpg|\.JPG|\.jpeg|\.JPEG|\.png|\.PNG|\.webp|\.WEBP|\.avif|\.AVIF)/', $url_tab['query'], $matches );
 			if ( isset( $matches[0][0] ) ) {
 				$img_url = $matches[0][0];
 			}

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1962,10 +1962,10 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 */
 	public function feedzy_image_encode( $img_url ) {
 		// Check if img url is set as an URL parameter.
-		$url_tab = wp_parse_url( $img_url );
-		if ( isset( $url_tab['query'] ) ) {
-			preg_match_all( '/(http|https):\/\/[^ ]+(\.gif|\.GIF|\.jpg|\.JPG|\.jpeg|\.JPEG|\.png|\.PNG|\.webp|\.WEBP|\.avif|\.AVIF)/', $url_tab['query'], $matches );
-			if ( isset( $matches[0][0] ) ) {
+		$parsed_url = wp_parse_url( $img_url );
+		if ( isset( $parsed_url['query'] ) ) {
+			preg_match_all( '/(http|https):\/\/[^ ]+(\.(gif|jpg|jpeg|png|webp|avif))/i', $parsed_url['query'], $matches );
+			if ( isset( $matches[0][0] ) && $this->is_image_url( $matches[0][0] ) ) {
 				$img_url = $matches[0][0];
 			}
 		}

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1663,7 +1663,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			'item_url_follow'       => isset( $sc['follow'] ) && 'yes' === $sc['follow'] ? 'nofollow' : '',
 			'item_url_title'        => $item->get_title(),
 			'item_img'              => $content_thumb,
-			'item_img_path'         => $this->feedzy_retrieve_image( $item, $sc ),
+			'item_img_path'         => isset( $sc['thumb'] ) && ( 'yes' === $sc['thumb'] || 'auto' === $sc['thumb'] ) ? $this->feedzy_retrieve_image( $item, $sc ) : '',
 			'item_title'            => $content_title,
 			'item_content_class'    => 'rss_content',
 			'item_content_style'    => '',

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -991,59 +991,47 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		$feed        = $this->fetch_feed( $feed_urls, $atts['refresh'], $atts );
 		$feed_items  = apply_filters( 'feedzy_get_feed_array', array(), $atts, $feed, $feed_urls, $sizes );
 		$total_items = count( $feed_items );
-		$count       = 0;
 
-		echo wp_kses(
-			sprintf(
-				// translators: %s is the total number of items available in the feed.
-				'<strong>' . __( 'Latest 5 feed items out of %s available from', 'feedzy-rss-feeds' ) . '</strong>',
-				$total_items
-			),
-			array(
-				'strong' => array(),
-			)
-		);
-
-		echo '<div class="feedzy-preview">';
-		$content = '<ul class="feedzy-preview-list">';
-
-		foreach ( $feed_items as $item ) {
-			if ( $count > 4 ) {
-				break;
+		$max_items_preview_count = 5;
+		$preview_feed_items      = array_slice( $feed_items, 0, $max_items_preview_count );
+		?>
+		<strong>
+			<?php
+				echo esc_html(
+					sprintf(
+						// translators: %1$s the number of maximum displayed items, %2$s is the total number of items available in the feed.
+						__( 'Latest %1$s feed items out of %2$s available from', 'feedzy-rss-feeds' ),
+						$max_items_preview_count,
+						$total_items
+					)
+				);
+			?>
+		</strong>
+		<div>
+			<ul class="feedzy-preview-list">
+			<?php
+			foreach ( $preview_feed_items as $item ) {
+				$datetime     = date_i18n( 'c', $item['item_date'] );
+				$time_content = date_i18n( 'Y-m-d', $item['item_date'] );
+				?>
+					<li <?php echo esc_attr( $item['itemAttr'] ); ?>>
+						<a href="<?php echo esc_url( $item['item_url'] ); ?>" target="_blank">
+							<?php echo esc_html( $item['item_title'] ); ?>
+						</a>
+						<br/>
+						<time
+							datetime="<?php echo esc_attr( $datetime ); ?>"
+							content="<?php echo esc_attr( $time_content ); ?>"
+						>
+							<?php echo esc_html( $this->get_humman_readable_time_diff( $item['item_date'] ) ); ?>
+						</time>
+					</li>
+				<?php
 			}
-			$content .= sprintf(
-				'<li %s><a href="%s" target="_blank">%s</a><br/><time datetime="%s" content="%s">%s</time></li>',
-				esc_attr( $item['itemAttr'] ),
-				esc_attr( $item['item_url'] ),
-				esc_html( $item['item_title'] ),
-				esc_attr( date_i18n( 'c', $item['item_date'] ) ),
-				esc_attr( date_i18n( 'Y-m-d', $item['item_date'] ) ),
-				esc_html( $this->get_humman_readable_time_diff( $item['item_date'] ) )
-			);
-			++$count;
-		}
-		$content .= '</ul>';
-		echo wp_kses(
-			$content,
-			array(
-				'ul'   => array(
-					'class' => array(),
-				),
-				'li'   => array(
-					'class' => array(),
-				),
-				'a'    => array(
-					'href'   => array(),
-					'target' => array(),
-				),
-				'time' => array(
-					'datetime' => array(),
-					'content'  => array(),
-				),
-				'br'   => array(),
-			)
-		);
-		echo '</div>';
+			?>
+			</ul>
+		</div>
+		<?php
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1138,11 +1138,6 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		$new_columns = $this->array_insert_before( 'slug', $columns, 'source', __( 'Source', 'feedzy-rss-feeds' ) );
-		if ( $new_columns ) {
-			$columns = $new_columns;
-		} else {
-			$columns['Source'] = __( 'source', 'feedzy-rss-feeds' );
-		}
 
 		return $columns;
 	}
@@ -1191,7 +1186,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			case 'source':
 				$src = get_post_meta( $post_id, 'feedzy_category_feed', true );
 				if ( empty( $src ) ) {
-							$src = __( 'No Source Configured', 'feedzy-rss-feeds' );
+					$src = __( 'No Source Configured', 'feedzy-rss-feeds' );
 				} else {
 					$urls = $this->normalize_urls( $src );
 					$src  = '';

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -897,6 +897,19 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 				'low'
 			);
 		}
+
+		if ( 'publish' === get_post_status() ) {
+			add_meta_box(
+				'feedzy_category_feeds_preview',
+				__( 'Feed Preview', 'feedzy-rss-feeds' ),
+				array(
+					$this,
+					'render_feed_preview',
+				),
+				'feedzy_categories',
+				'side'
+			);
+		}
 	}
 
 	/**
@@ -939,10 +952,116 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			)
 			. '</strong><br/><br/>'
 			. $invalid
-			. '<textarea name="feedzy_category_feed" rows="15" class="widefat" placeholder="' . __( 'Place your URL\'s here followed by a comma.', 'feedzy-rss-feeds' ) . '" >' . $feed . '</textarea>
-			<p><a href="' . esc_url( 'https://docs.themeisle.com/article/1119-feedzy-rss-feeds-documentation#categories' ) . '" target="_blank">' . __( 'Learn how to organize feeds in Groups', 'feedzy-rss-feeds' ) . '</a></p>
+			. '<textarea name="feedzy_category_feed" rows="10" class="widefat" placeholder="themeisle.com/blog/feed/, https://wptavern.com/feed/, https://www.wpbeginner.com/feed/, https://wpshout.com/feed/, https://planet.wordpress.org/feed/" >' . $feed . '</textarea>
+			<div class="validate-feeds-actions">
+			<span class="spinner"></span>
+			<button class="button validate-feeds" ' . esc_attr( empty( $feed ) ? 'disabled' : '' ) . '>' . __( 'Validate & Remove Invalid Feeds', 'feedzy-rss-feeds' ) . '</button>
+			</div>
         ';
 		echo wp_kses( $output, apply_filters( 'feedzy_wp_kses_allowed_html', array() ) );
+	}
+
+	/**
+	 * Render the feed preview metabox.
+	 *
+	 * @return void
+	 */
+	public function render_feed_preview() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['action'] ) && 'edit' !== $_GET['action'] ) {
+			return;
+		}
+		$feeds     = get_post_meta( get_the_ID(), 'feedzy_category_feed', true );
+		$feed_urls = $this->normalize_urls( $feeds );
+		if ( empty( $feed_urls ) ) {
+			echo '<p>' . esc_html__( 'No feeds available for preview.', 'feedzy-rss-feeds' ) . '</p>';
+			return;
+		}
+		$shortcode   = array(
+			'sort'  => 'date_desc',
+			'thumb' => 'no',
+			'max'   => 0,
+		);
+		$atts        = $this->get_short_code_attributes( $shortcode );
+		$atts        = $this->sanitize_attr( $atts, $feed_urls );
+		$sizes       = array(
+			'width'  => 0,
+			'height' => 0,
+		);
+		$feed        = $this->fetch_feed( $feed_urls, $atts['refresh'], $atts );
+		$feed_items  = apply_filters( 'feedzy_get_feed_array', array(), $atts, $feed, $feed_urls, $sizes );
+		$total_items = count( $feed_items );
+		$count       = 0;
+
+		echo wp_kses(
+			sprintf(
+				// translators: %s is the total number of items available in the feed.
+				'<strong>' . __( 'Latest 5 feed items out of %s available from', 'feedzy-rss-feeds' ) . '</strong>',
+				$total_items
+			),
+			array(
+				'strong' => array(),
+			)
+		);
+
+		echo '<div class="feedzy-preview">';
+		$content = '<ul class="feedzy-preview-list">';
+
+		foreach ( $feed_items as $item ) {
+			if ( $count > 4 ) {
+				break;
+			}
+			$content .= sprintf(
+				'<li %s><a href="%s" target="_blank">%s</a><br/><time datetime="%s" content="%s">%s</time></li>',
+				esc_attr( $item['itemAttr'] ),
+				esc_attr( $item['item_url'] ),
+				esc_html( $item['item_title'] ),
+				esc_attr( date_i18n( 'c', $item['item_date'] ) ),
+				esc_attr( date_i18n( 'Y-m-d', $item['item_date'] ) ),
+				esc_html( $this->get_humman_readable_time_diff( $item['item_date'] ) )
+			);
+			++$count;
+		}
+		$content .= '</ul>';
+		echo wp_kses(
+			$content,
+			array(
+				'ul'   => array(
+					'class' => array(),
+				),
+				'li'   => array(
+					'class' => array(),
+				),
+				'a'    => array(
+					'href'   => array(),
+					'target' => array(),
+				),
+				'time' => array(
+					'datetime' => array(),
+					'content'  => array(),
+				),
+				'br'   => array(),
+			)
+		);
+		echo '</div>';
+	}
+
+	/**
+	 * Get human readable time difference.
+	 *
+	 * @param int $item_publish_time The item publish time.
+	 *
+	 * @return string
+	 */
+	private function get_humman_readable_time_diff( $item_publish_time ) {
+		$array     = current_datetime();
+		$localtime = $array->getTimestamp() + $array->getOffset();
+
+		return sprintf(
+			// translators: %s is the time difference.
+			__( '%s ago', 'feedzy-rss-feeds' ),
+			human_time_diff( $item_publish_time, $localtime )
+		);
 	}
 
 	/**
@@ -1030,6 +1149,13 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			$columns['actions'] = __( 'Actions', 'feedzy-rss-feeds' );
 		}
 
+		$new_columns = $this->array_insert_before( 'slug', $columns, 'source', __( 'Source', 'feedzy-rss-feeds' ) );
+		if ( $new_columns ) {
+			$columns = $new_columns;
+		} else {
+			$columns['Source'] = __( 'source', 'feedzy-rss-feeds' );
+		}
+
 		return $columns;
 	}
 
@@ -1073,6 +1199,33 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 				break;
 			case 'actions':
 				echo wp_kses_post( sprintf( '<button class="button button-primary validate-category" title="%s" data-category-id="%d">%s</button>', __( 'Click to remove invalid URLs from this category', 'feedzy-rss-feeds' ), $post_id, __( 'Validate & Clean', 'feedzy-rss-feeds' ) ) );
+				break;
+			case 'source':
+				$src = get_post_meta( $post_id, 'feedzy_category_feed', true );
+				if ( empty( $src ) ) {
+							$src = __( 'No Source Configured', 'feedzy-rss-feeds' );
+				} else {
+					$urls = $this->normalize_urls( $src );
+					$src  = '';
+					if ( is_array( $urls ) ) {
+
+						foreach ( $urls as $key => $url ) {
+							$too_long = 130;
+							if ( strlen( $src ) > $too_long ) {
+								$src .= '...';
+								break;
+							} else {
+								$src .= '<a href="' . $url . '" target="_blank" title="' . __( 'Click to view', 'feedzy-rss-feeds' ) . '">' . $url . '</a>';
+								if ( count( $urls ) > $key + 1 ) {
+									$src .= ', ';
+								}
+							}
+						}
+					} else {
+						$src .= '<a href="' . esc_url( $urls ) . '" target="_blank" title="' . __( 'Click to view', 'feedzy-rss-feeds' ) . '">' . esc_html( $urls ) . '</a>';
+					}
+				}
+				echo wp_kses_post( $src );
 				break;
 			default:
 				break;
@@ -1709,6 +1862,23 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 				}
 				wp_send_json_success( array( 'invalid' => count( $invalid ) ) );
 				break;
+			case 'validate_feeds_group':
+				$feeds = isset( $_POST['feeds'] ) ? sanitize_text_field( wp_unslash( $_POST['feeds'] ) ) : '';
+				if ( empty( $feeds ) ) {
+					wp_send_json_error( __( 'No feeds provided for validation.', 'feedzy-rss-feeds' ) );
+				}
+				$feeds = $this->normalize_urls( $feeds );
+				if ( ! is_array( $feeds ) ) {
+					$feeds = array( $feeds );
+				}
+				$valid   = $this->get_valid_source_urls( $feeds, '1_mins', false );
+				$invalid = array_diff( $feeds, $valid );
+				wp_send_json_success(
+					array(
+						'valid'   => $valid,
+						'invalid' => $invalid,
+					)
+				);
 		}
 	}
 

--- a/includes/feedzy-rss-feeds-activator.php
+++ b/includes/feedzy-rss-feeds-activator.php
@@ -82,7 +82,15 @@ class Feedzy_Rss_Feeds_Activator {
 
 		$news_group = wp_insert_post( $group_args );
 
-		$feed_groups = 'https://themeisle.com/blog/feed/, https://wptavern.com/feed/, https://www.wpbeginner.com/feed/, https://wpshout.com/feed/, https://planet.wordpress.org/feed/';
+		$default_feed_urls = array(
+			'https://themeisle.com/blog/feed/',
+			'https://wptavern.com/feed/',
+			'https://www.wpbeginner.com/feed/',
+			'https://wpshout.com/feed/',
+			'https://planet.wordpress.org/feed/',
+		);
+
+		$feed_groups = implode( ', ', array_map( 'esc_url', $default_feed_urls ) );
 
 		add_post_meta( $news_group, 'feedzy_category_feed', $feed_groups );
 

--- a/includes/feedzy-rss-feeds-activator.php
+++ b/includes/feedzy-rss-feeds-activator.php
@@ -57,5 +57,35 @@ class Feedzy_Rss_Feeds_Activator {
 				)
 			);
 		}
+		self::add_feeds_group();
+	}
+
+	/**
+	 * Adds a default feeds group with some popular WordPress-related feeds.
+	 *
+	 * This method checks if a feeds group already exists, and if not, creates one
+	 * with a set of predefined feeds.
+	 *
+	 * @return void
+	 */
+	public static function add_feeds_group() {
+		if ( get_option( '_feedzy_news_group_id', false ) ) {
+			return;
+		}
+
+		$group_args = array(
+			'post_title'   => __( 'News sites', 'feedzy-rss-feeds' ),
+			'post_type'    => 'feedzy_categories',
+			'post_status'  => 'publish',
+			'post_content' => '',
+		);
+
+		$news_group = wp_insert_post( $group_args );
+
+		$feed_groups = 'https://themeisle.com/blog/feed/, https://wptavern.com/feed/, https://www.wpbeginner.com/feed/, https://wpshout.com/feed/, https://planet.wordpress.org/feed/';
+
+		add_post_meta( $news_group, 'feedzy_category_feed', $feed_groups );
+
+		update_option( '_feedzy_news_group_id', $news_group );
 	}
 }

--- a/includes/feedzy-rss-feeds-feed-tweaks.php
+++ b/includes/feedzy-rss-feeds-feed-tweaks.php
@@ -466,10 +466,13 @@ add_filter(
 				'value'       => array(),
 				'class'       => array(),
 				'data-feedzy' => array(),
+				'placeholder' => array(),
+				'rows'        => array(),
 			),
 			'button'   => array(
-				'class' => array(),
-				'id'    => array(),
+				'class'    => array(),
+				'id'       => array(),
+				'disabled' => array(),
 			),
 			'p'        => array(
 				'class' => array(),

--- a/js/categories.js
+++ b/js/categories.js
@@ -37,16 +37,12 @@
     // validate feeds group.
     function validateFeeds() {
         $('#feedzy_category_feeds textarea[name="feedzy_category_feed"]').on('input', function() {
-            if ($(this).val().length < 1) {
-                $('.validate-feeds').attr('disabled', true);
-            } else {
-                $('.validate-feeds').attr('disabled', false);
-            }
+            $('.validate-feeds').attr('disabled', 1 > $(this).val().length );
         });
 
         $('#feedzy_category_feeds .button.validate-feeds').on('click', function(e) {
             e.preventDefault();
-            var button = $(this);
+            const button = $(this);
             button.attr('disabled', true);
             $('#feedzy_category_feeds .spinner').addClass('is-active');
             $.ajax({

--- a/js/categories.js
+++ b/js/categories.js
@@ -4,6 +4,7 @@
     
     $(document).ready(function(){
         init();
+        validateFeeds();
     });
 
     function init(){
@@ -30,6 +31,40 @@
                     }, 5000 );
                 }
             });
+        });
+    }
+
+    // validate feeds group.
+    function validateFeeds() {
+        $('#feedzy_category_feeds textarea[name="feedzy_category_feed"]').on('input', function() {
+            if ($(this).val().length < 1) {
+                $('.validate-feeds').attr('disabled', true);
+            } else {
+                $('.validate-feeds').attr('disabled', false);
+            }
+        });
+
+        $('#feedzy_category_feeds .button.validate-feeds').on('click', function(e) {
+            e.preventDefault();
+            var button = $(this);
+            button.attr('disabled', true);
+            $('#feedzy_category_feeds .spinner').addClass('is-active');
+            $.ajax({
+                url: ajaxurl,
+                method: 'POST',
+                data: {
+                    action: 'feedzy_categories',
+                    _action: 'validate_feeds_group',
+                    security: feedzy.ajax.security,
+                    feeds: $('textarea[name="feedzy_category_feed"]').val()
+                },
+                success: function(data) {
+                    if (data.success) {
+                        $('textarea[name="feedzy_category_feed"]').val(data.data.valid.join(', '));
+                        $('#feedzy_category_feeds .spinner').removeClass('is-active');
+                    }
+                }
+            })
         });
     }
 


### PR DESCRIPTION
### Summary
I have improved the feed group UX and added the default WP news group on activation.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/873