### PR TITLE
feat: can now embed youtube videos and shorts

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -185,11 +185,11 @@ class Feedzy_Rss_Feeds_Import {
 	/**
 	 * Add attributes to $item_array.
 	 *
-	 * @param array  $item_array The item attributes array.
-	 * @param object $item The feed item.
-	 * @param array  $sc The shortcode attributes array.
-	 * @param int    $index The item number.
-	 * @param int    $item_index The real index of this item in the feed.
+	 * @param array          $item_array The item attributes array.
+	 * @param SimplePie\Item $item The feed item.
+	 * @param array          $sc The shortcode attributes array.
+	 * @param int            $index The item number.
+	 * @param int            $item_index The real index of this item in the feed.
 	 * @return mixed
 	 * @since 1.0.0
 	 * @access public
@@ -213,7 +213,7 @@ class Feedzy_Rss_Feeds_Import {
 	 * Fetches additional information for each item.
 	 *
 	 * @param array<string, string > $item_array The item attributes array.
-	 * @param object                 $item The feed item.
+	 * @param SimplePie\Item         $item The feed item.
 	 * @param array<string, mixed>   $sc The shortcode attributes array. This will be empty through the block editor.
 	 * 
 	 * @return array<string, string>
@@ -231,10 +231,10 @@ class Feedzy_Rss_Feeds_Import {
 		}
 
 		$host = wp_parse_url( $url, PHP_URL_HOST );
-		// remove all dots in the hostname so that shortforms such as youtu.be can also be resolved.
-		$host = str_replace( array( '.', 'www' ), '', $host );
 
-		// youtube.
+		// Remove all dots in the hostname so that shortforms such as youtu.be can also be resolved.
+		$host = str_replace( array( '.', 'www' ), '', $host );
+		
 		if ( ! in_array( $host, array( 'youtubecom', 'youtube' ), true ) ) {
 			// Not a YouTube link, return the item array as is.
 			return $item_array;
@@ -268,9 +268,9 @@ class Feedzy_Rss_Feeds_Import {
 			}
 		}
 
-		$embed_shortcode            = '[embed]' . $url . '[/embed]';
+		$embed_video_shortcode      = '[embed]' . $url . '[/embed]';
 		$should_overwrite           = str_contains( $item_array['item_content'], 'Post Content' );
-		$item_array['item_content'] = ( $should_overwrite ? '' : $item_array['item_content'] ) . $embed_shortcode;
+		$item_array['item_content'] = ( $should_overwrite ? '' : $item_array['item_content'] ) . $embed_video_shortcode;
 		
 		return $item_array;
 	}
@@ -278,11 +278,10 @@ class Feedzy_Rss_Feeds_Import {
 	/**
 	 * Retrieve the categories.
 	 *
-	 * @param string $dumb The initial categories (only a placeholder argument for the filter).
-	 * @param object $item The feed item.
+	 * @param string         $dumb The initial categories (only a placeholder argument for the filter).
+	 * @param SimplePie\Item $item The feed item.
 	 *
 	 * @return string
-	 * @since   ?
 	 * @access  public
 	 */
 	public function retrieve_categories( $dumb, $item ) {
@@ -290,11 +289,7 @@ class Feedzy_Rss_Feeds_Import {
 		$categories = $item->get_categories();
 		if ( $categories ) {
 			foreach ( $categories as $category ) {
-				if ( is_string( $category ) ) {
-					$cats[] = $category;
-				} else {
-					$cats[] = $category->get_label();
-				}
+				$cats[] = $category->get_label();
 			}
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Moved the YouTube handling from PRO to FREE (https://github.com/Codeinwp/feedzy-rss-feeds-pro/pull/922)
- Switched to `embed` instead of `video` shortcode since `embed` has support for YouTube shorts.
- Fixed various issues reported by PHPStan.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="3700" height="2939" alt="CleanShot 2025-07-29 at 15 41 00@2x" src="https://github.com/user-attachments/assets/6e34ab27-96d0-4a27-8ce8-44cacca260c3" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use a link to a channel using YouTube Short (e.g. https://www.youtube.com/feeds/videos.xml?channel_id=UCSHmNs-_UuU1CfPhSbilTZQ ).

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/841
<!-- Should look like this: `Closes #1, #2, #3.` . -->
