### PR TITLE
feat: add aspect ratio control for Feedzy Classic Block

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1438,7 +1438,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 				if ( isset( $sc['aspectRatio'] ) ) {
 					$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
-				} else if ( isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) ) {
+				} elseif ( isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) ) {
 					$img_style .= 'width:' . $sizes['width'] . 'px;';
 				}
 

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1406,8 +1406,8 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$item_link = $item->get_feed()->get_permalink();
 			}
 		}
-		$new_link    = apply_filters( 'feedzy_item_url_filter', $item_link, $sc, $item );
-		$amp_running = function_exists( 'amp_is_request' ) && amp_is_request();
+		$new_link      = apply_filters( 'feedzy_item_url_filter', $item_link, $sc, $item );
+		$amp_running   = function_exists( 'amp_is_request' ) && amp_is_request();
 		$content_thumb = '';
 
 		$thumbnail_to_use = '';
@@ -1424,7 +1424,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 		
 		if ( ! empty( $thumbnail_to_use ) && is_string( $thumbnail_to_use ) ) {
-			$img_style     = '';
+			$img_style = '';
 
 			if ( isset( $sizes['height'] ) && is_numeric( $sizes['height'] ) ) {
 				$img_style .= 'height:' . $sizes['height'] . 'px;';

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -620,6 +620,8 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				'default'               => '',
 				// thumbs pixel size.
 				'size'                  => '',
+				// default aspect ratio for the image.
+				'aspectRatio'			=> 'auto',
 				// only display item if title contains specific keywords (Use comma(,) and plus(+) keyword).
 				'keywords_title'        => '',
 				// only display item if title OR content contains specific keywords (Use comma(,) and plus(+) keyword).
@@ -1421,10 +1423,24 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				)
 			) {
 				$the_thumbnail  = $this->feedzy_image_encode( $the_thumbnail );
-				$content_thumb .= '<span class="fetched" style="background-image:  url(\'' . $the_thumbnail . '\');" title="' . esc_attr( $item->get_title() ) . '"></span>';
+
+				$img_style	 = '';
+
+				if ( isset(  $sizes['height'] ) && is_numeric( $sizes['height'] ) ) {
+					$img_style .= 'height:' . $sizes['height'] . 'px;';
+				}
+
+				if ( isset( $sc['aspectRatio'] ) ) {
+					$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
+				} else if ( isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) ) {
+					$img_style .= 'width:' . $sizes['width'] . 'px;';
+				}
+
+				$content_thumb .= '<img decoding="async" src="' . $the_thumbnail . '" title="' . esc_attr( $item->get_title() ) . '" style="' . $img_style . '">';
+
 				if ( ! isset( $sc['amp'] ) || 'no' !== $sc['amp'] ) {
 					$content_thumb .= '<amp-img width="' . $sizes['width'] . '" height="' . $sizes['height'] . '" src="' . $the_thumbnail . '">';
-				}
+					}
 			}
 
 			if ( empty( $the_thumbnail ) && 'yes' === $sc['thumb'] ) {
@@ -1593,11 +1609,22 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		if ( empty( $item_content ) ) {
 			$item_content = esc_html__( 'Post Content', 'feedzy-rss-feeds' );
 		}
+
+		$img_style = '';
+		if ( isset( $sizes['height'] ) ) {
+			$img_style = 'height:' . $sizes['height'] . 'px;';
+			if ( isset( $sc['aspectRatio'] ) ) {
+				$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
+			} else if( isset( $sizes['width'] ) ) {
+				$img_style .= 'width:' . $sizes['width'] . 'px;';
+			}
+		}
+
 		$item_array = array(
 			'feed_url'              => $item->get_feed()->subscribe_url(),
 			'item_unique_hash'      => wp_hash( $item->get_permalink() ),
 			'item_img_class'        => 'rss_image',
-			'item_img_style'        => 'width:' . $sizes['width'] . 'px; height:' . $sizes['height'] . 'px;',
+			'item_img_style'        => $img_style,
 			'item_url'              => $new_link,
 			'item_url_target'       => $sc['target'],
 			'item_url_follow'       => isset( $sc['follow'] ) && 'yes' === $sc['follow'] ? 'nofollow' : '',

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -621,7 +621,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				// thumbs pixel size.
 				'size'                  => '',
 				// default aspect ratio for the image.
-				'aspectRatio'			=> 'auto',
+				'aspectRatio'           => 'auto',
 				// only display item if title contains specific keywords (Use comma(,) and plus(+) keyword).
 				'keywords_title'        => '',
 				// only display item if title OR content contains specific keywords (Use comma(,) and plus(+) keyword).
@@ -1422,12 +1422,18 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 					)
 				)
 			) {
-				$the_thumbnail  = $this->feedzy_image_encode( $the_thumbnail );
+				$the_thumbnail = $this->feedzy_image_encode( $the_thumbnail );
 
-				$img_style	 = '';
+				$img_style = '';
 
-				if ( isset(  $sizes['height'] ) && is_numeric( $sizes['height'] ) ) {
+				if ( isset( $sizes['height'] ) && is_numeric( $sizes['height'] ) ) {
 					$img_style .= 'height:' . $sizes['height'] . 'px;';
+				}
+
+				if ( isset( $sc['aspectRatio'] ) ) {
+					$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
+				} elseif ( isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) ) {
+					$img_style .= 'width:' . $sizes['width'] . 'px;';
 				}
 
 				if ( isset( $sc['aspectRatio'] ) ) {
@@ -1440,7 +1446,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 				if ( ! isset( $sc['amp'] ) || 'no' !== $sc['amp'] ) {
 					$content_thumb .= '<amp-img width="' . $sizes['width'] . '" height="' . $sizes['height'] . '" src="' . $the_thumbnail . '">';
-					}
+				}
 			}
 
 			if ( empty( $the_thumbnail ) && 'yes' === $sc['thumb'] ) {
@@ -1615,7 +1621,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			$img_style = 'height:' . $sizes['height'] . 'px;';
 			if ( isset( $sc['aspectRatio'] ) ) {
 				$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
-			} else if( isset( $sizes['width'] ) ) {
+			} elseif ( isset( $sizes['width'] ) ) {
 				$img_style .= 'width:' . $sizes['width'] . 'px;';
 			}
 		}

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -621,7 +621,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				// thumbs pixel size.
 				'size'                  => '',
 				// default aspect ratio for the image.
-				'aspectRatio'           => 'auto',
+				'aspectRatio'           => '1',
 				// only display item if title contains specific keywords (Use comma(,) and plus(+) keyword).
 				'keywords_title'        => '',
 				// only display item if title OR content contains specific keywords (Use comma(,) and plus(+) keyword).
@@ -1406,64 +1406,54 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$item_link = $item->get_feed()->get_permalink();
 			}
 		}
-		$new_link = apply_filters( 'feedzy_item_url_filter', $item_link, $sc, $item );
+		$new_link    = apply_filters( 'feedzy_item_url_filter', $item_link, $sc, $item );
+		$amp_running = function_exists( 'amp_is_request' ) && amp_is_request();
+		$content_thumb = '';
 
-		// Fetch image thumbnail.
+		$thumbnail_to_use = '';
 		if ( 'yes' === $sc['thumb'] || 'auto' === $sc['thumb'] ) {
-			$the_thumbnail = $this->feedzy_retrieve_image( $item, $sc );
-			$content_thumb = '';
+			// Fetch image thumbnail.
+			$thumbnail_to_use = $this->feedzy_retrieve_image( $item, $sc );
+			$thumbnail_to_use = $this->feedzy_image_encode( $thumbnail_to_use );
+
+			if ( empty( $thumbnail_to_use ) && 'yes' === $sc['thumb'] ) {
+				$thumbnail_to_use = $sc['default'];
+			}
+		} else {
+			$thumbnail_to_use = $sc['default'];
+		}
+		
+		if ( ! empty( $thumbnail_to_use ) && is_string( $thumbnail_to_use ) ) {
+			$img_style     = '';
+
+			if ( isset( $sizes['height'] ) && is_numeric( $sizes['height'] ) ) {
+				$img_style .= 'height:' . $sizes['height'] . 'px;';
+			}
+
+			if ( isset( $sc['aspectRatio'] ) && '1' !== $sc['aspectRatio'] ) {
+				$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . '; object-fit: fill;';
+			}
+			
 			if (
-				is_string( $the_thumbnail ) && ! empty( $the_thumbnail ) &&
+				isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) && 
 				(
-					'yes' === $sc['thumb'] ||
+					$sizes['width'] !== $sizes['height'] || // Note: Custom modification via filters.
 					(
-						'auto' === $sc['thumb'] &&
-						! strpos( $the_thumbnail, 'img/feedzy.svg' )
+						isset( $sc['aspectRatio'] ) &&
+						(
+							( 'auto' === $sc['aspectRatio'] && $amp_running ) || // Note: AMP compatibility. Auto without `height` breaks the layout.
+							'1' === $sc['aspectRatio'] // Note: Backward compatiblity.
+						)
 					)
 				)
 			) {
-				$the_thumbnail = $this->feedzy_image_encode( $the_thumbnail );
-
-				$img_style = '';
-
-				if ( isset( $sizes['height'] ) && is_numeric( $sizes['height'] ) ) {
-					$img_style .= 'height:' . $sizes['height'] . 'px;';
-				}
-
-				if ( isset( $sc['aspectRatio'] ) ) {
-					$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
-				} elseif ( isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) ) {
-					$img_style .= 'width:' . $sizes['width'] . 'px;';
-				}
-
-				if ( isset( $sc['aspectRatio'] ) ) {
-					$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
-				} elseif ( isset( $sizes['width'] ) && is_numeric( $sizes['width'] ) ) {
-					$img_style .= 'width:' . $sizes['width'] . 'px;';
-				}
-
-				$content_thumb .= '<img decoding="async" src="' . $the_thumbnail . '" title="' . esc_attr( $item->get_title() ) . '" style="' . $img_style . '">';
-
-				if ( ! isset( $sc['amp'] ) || 'no' !== $sc['amp'] ) {
-					$content_thumb .= '<amp-img width="' . $sizes['width'] . '" height="' . $sizes['height'] . '" src="' . $the_thumbnail . '">';
-				}
+				$img_style .= 'width:' . $sizes['width'] . 'px;';
 			}
 
-			if ( empty( $the_thumbnail ) && 'yes' === $sc['thumb'] ) {
-				$content_thumb .= '<span class="default" style="background-image:url(' . $sc['default'] . ');" title="' . esc_attr( $item->get_title() ) . '"></span>';
-				if ( ! isset( $sc['amp'] ) || 'no' !== $sc['amp'] ) {
-					$content_thumb .= '<amp-img width="' . $sizes['width'] . '" height="' . $sizes['height'] . '" src="' . $sc['default'] . '">';
-				}
-			}
-			$content_thumb = apply_filters( 'feedzy_thumb_output', $content_thumb, $feed_url, $sizes, $item );
-		} else {
-			$content_thumb  = '';
-			$content_thumb .= '<span class="default" style="width:' . $sizes['width'] . 'px; height:' . $sizes['height'] . 'px; background-image:url(' . $sc['default'] . ');" title="' . $item->get_title() . '"></span>';
-			if ( ! isset( $sc['amp'] ) || 'no' !== $sc['amp'] ) {
-				$content_thumb .= '<amp-img width="' . $sizes['width'] . '" height="' . $sizes['height'] . '" src="' . $sc['default'] . '">';
-			}
-			$content_thumb = apply_filters( 'feedzy_thumb_output', $content_thumb, $feed_url, $sizes, $item );
+			$content_thumb .= '<img decoding="async" src="' . $thumbnail_to_use . '" title="' . esc_attr( $item->get_title() ) . '" style="' . $img_style . '">';
+			$content_thumb  = apply_filters( 'feedzy_thumb_output', $content_thumb, $feed_url, $sizes, $item );
 		}
+
 		$content_title = html_entity_decode( $item->get_title(), ENT_QUOTES, 'UTF-8' );
 		if ( is_numeric( $sc['title'] ) ) {
 			$length = intval( $sc['title'] );
@@ -1619,7 +1609,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		$img_style = '';
 		if ( isset( $sizes['height'] ) ) {
 			$img_style = 'height:' . $sizes['height'] . 'px;';
-			if ( isset( $sc['aspectRatio'] ) ) {
+			if ( isset( $sc['aspectRatio'] ) && '1' !== $sc['aspectRatio'] ) {  
 				$img_style .= 'aspect-ratio:' . $sc['aspectRatio'] . ';';
 			} elseif ( isset( $sizes['width'] ) ) {
 				$img_style .= 'width:' . $sizes['width'] . 'px;';

--- a/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
@@ -171,7 +171,7 @@ class Feedzy_Rss_Feeds_Gutenberg_Block {
 						'type'    => 'number',
 						'default' => 150,
 					),
-					'aspectRatio'    => array(
+					'aspectRatio'     => array(
 						'type'    => 'string',
 						'default' => 'auto',
 					),

--- a/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
@@ -173,7 +173,7 @@ class Feedzy_Rss_Feeds_Gutenberg_Block {
 					),
 					'aspectRatio'     => array(
 						'type'    => 'string',
-						'default' => 'auto',
+						'default' => '1',
 					),
 					'price'           => array(
 						'type'    => 'boolean',

--- a/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
@@ -171,6 +171,10 @@ class Feedzy_Rss_Feeds_Gutenberg_Block {
 						'type'    => 'number',
 						'default' => 150,
 					),
+					'aspectRatio'    => array(
+						'type'    => 'string',
+						'default' => 'auto',
+					),
 					'price'           => array(
 						'type'    => 'boolean',
 						'default' => true,

--- a/js/FeedzyBlock/Editor.js
+++ b/js/FeedzyBlock/Editor.js
@@ -53,6 +53,7 @@ class Editor extends Component {
 		this.onThumb = this.onThumb.bind(this);
 		this.onDefault = this.onDefault.bind(this);
 		this.onSize = this.onSize.bind(this);
+		this.onAspectRatio = this.onAspectRatio.bind(this);
 		this.onReferralURL = this.onReferralURL.bind(this);
 		this.onColumns = this.onColumns.bind(this);
 		this.onTemplate = this.onTemplate.bind(this);
@@ -325,6 +326,9 @@ class Editor extends Component {
 	}
 	onSize(value) {
 		this.props.setAttributes({ size: !value ? 150 : Number(value) });
+	}
+	onAspectRatio(value) {
+		this.props.setAttributes({ aspectRatio: value });
 	}
 	onReferralURL(value) {
 		window.tiTrk?.with('feedzy').add({ feature: 'block-referral-url' });
@@ -669,9 +673,9 @@ class Editor extends Component {
 											<div
 												className="rss_image"
 												style={{
-													width:
+													aspectRatio:
 														this.props.attributes
-															.size + 'px',
+															.aspectRatio,
 													height:
 														this.props.attributes
 															.size + 'px',
@@ -684,11 +688,10 @@ class Editor extends Component {
 															item.title
 														)}
 														style={{
-															width:
+															aspectRatio:
 																this.props
 																	.attributes
-																	.size +
-																'px',
+																	.aspectRatio,
 															height:
 																this.props
 																	.attributes
@@ -696,29 +699,26 @@ class Editor extends Component {
 																'px',
 														}}
 													>
-														<span
-															className="fetched"
+														<img
+															src={this.getImageURL(
+																item,
+																false
+															)}
+															alt={unescapeHTML(
+																item.title
+															)}
 															style={{
-																width:
+																aspectRatio:
 																	this.props
 																		.attributes
-																		.size +
-																	'px',
+																		.aspectRatio,
 																height:
 																	this.props
 																		.attributes
 																		.size +
 																	'px',
-																backgroundImage:
-																	this.getImageURL(
-																		item,
-																		true
-																	),
 															}}
-															title={unescapeHTML(
-																item.title
-															)}
-														></span>
+														/>
 													</a>
 												</Disabled>
 											</div>

--- a/js/FeedzyBlock/attributes.js
+++ b/js/FeedzyBlock/attributes.js
@@ -117,7 +117,7 @@ const attributes = {
 	disableStyle: {
 		type: 'boolean',
 		default: false,
-  },
+	},
 	follow: {
 		type: 'string',
 		default: 'no',
@@ -137,7 +137,11 @@ const attributes = {
 	_dry_run_tags_: {
 		type: 'string',
 		default: '',
-	}
+	},
+	aspectRatio: {
+		type: 'string',
+		default: 'auto',
+	},
 };
 
 export default attributes;

--- a/js/FeedzyBlock/attributes.js
+++ b/js/FeedzyBlock/attributes.js
@@ -140,7 +140,7 @@ const attributes = {
 	},
 	aspectRatio: {
 		type: 'string',
-		default: 'auto',
+		default: '1',
 	},
 };
 

--- a/js/FeedzyBlock/inspector.js
+++ b/js/FeedzyBlock/inspector.js
@@ -667,7 +667,7 @@ class Inspector extends Component {
 												)}
 												value={
 													this.props.attributes
-														.aspectRatio || '1:1'
+														.aspectRatio
 												}
 												options={[
 													{
@@ -682,7 +682,7 @@ class Inspector extends Component {
 															'1:1 (Square)',
 															'feedzy-rss-feeds'
 														),
-														value: '1/1',
+														value: '1',
 													},
 													{
 														label: __(

--- a/js/FeedzyBlock/inspector.js
+++ b/js/FeedzyBlock/inspector.js
@@ -660,6 +660,72 @@ class Inspector extends Component {
 													this.props.edit.onSize
 												}
 											/>
+											<SelectControl
+												label={__(
+													'Aspect Ratio',
+													'feedzy-rss-feeds'
+												)}
+												value={
+													this.props.attributes
+														.aspectRatio || '1:1'
+												}
+												options={[
+													{
+														label: __(
+															'Original',
+															'feedzy-rss-feeds'
+														),
+														value: 'auto',
+													},
+													{
+														label: __(
+															'1:1 (Square)',
+															'feedzy-rss-feeds'
+														),
+														value: '1 / 1',
+													},
+													{
+														label: __(
+															'16:9 (Widescreen)',
+															'feedzy-rss-feeds'
+														),
+														value: '16 / 9',
+													},
+													{
+														label: __(
+															'4:3 (Standard)',
+															'feedzy-rss-feeds'
+														),
+														value: '4 / 3',
+													},
+													{
+														label: __(
+															'3:2 (Classic)',
+															'feedzy-rss-feeds'
+														),
+														value: '3 / 2',
+													},
+													{
+														label: __(
+															'2:1 (Banner)',
+															'feedzy-rss-feeds'
+														),
+														value: '2 / 1',
+													},
+													{
+														label: __(
+															'3:4 (Portrait)',
+															'feedzy-rss-feeds'
+														),
+														value: '3 / 4',
+													},
+												]}
+												onChange={
+													this.props.edit
+														.onAspectRatio
+												}
+												className="feedzy-aspect-ratio-select"
+											/>
 										</Fragment>
 									)}
 								</PanelBody>

--- a/js/FeedzyBlock/inspector.js
+++ b/js/FeedzyBlock/inspector.js
@@ -682,21 +682,21 @@ class Inspector extends Component {
 															'1:1 (Square)',
 															'feedzy-rss-feeds'
 														),
-														value: '1 / 1',
-													},
-													{
-														label: __(
-															'16:9 (Widescreen)',
-															'feedzy-rss-feeds'
-														),
-														value: '16 / 9',
+														value: '1/1',
 													},
 													{
 														label: __(
 															'4:3 (Standard)',
 															'feedzy-rss-feeds'
 														),
-														value: '4 / 3',
+														value: '4/3',
+													},
+													{
+														label: __(
+															'3:4 (Portrait)',
+															'feedzy-rss-feeds'
+														),
+														value: '3/4',
 													},
 													{
 														label: __(
@@ -707,17 +707,24 @@ class Inspector extends Component {
 													},
 													{
 														label: __(
-															'2:1 (Banner)',
+															'2:3 (Clasic Portrait)',
 															'feedzy-rss-feeds'
 														),
-														value: '2 / 1',
+														value: '2/3',
 													},
 													{
 														label: __(
-															'3:4 (Portrait)',
+															'16:9 (Widescreen)',
 															'feedzy-rss-feeds'
 														),
-														value: '3 / 4',
+														value: '16/9',
+													},
+													{
+														label: __(
+															'9:16 (Vertical)',
+															'feedzy-rss-feeds'
+														),
+														value: '9/16',
 													},
 												]}
 												onChange={

--- a/tests/e2e/specs/classic-block.spec.js
+++ b/tests/e2e/specs/classic-block.spec.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe('Feedzy Classic Block', () => {
+	test('check aspect ratio default', async ({ editor, page, admin }) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'feedzy-rss-feeds/feedzy-block',
+			attributes: {
+				feeds: 'https://www.nasa.gov/feeds/iotd-feed/',
+				max: 1,
+			},
+		});
+
+		const postId = await editor.publishPost();
+		await page.goto(`/?p=${postId}`);
+
+		const image = page.locator('.feedzy-rss .rss_image img');
+		await expect(image).toHaveAttribute(
+			'style',
+			'height:150px;width:150px;'
+		);
+	});
+
+	test('check aspect ratio (3/2)', async ({ editor, page, admin }) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'feedzy-rss-feeds/feedzy-block',
+			attributes: {
+				aspectRatio: '3/2',
+				feeds: 'https://www.nasa.gov/feeds/iotd-feed/',
+				max: 1,
+			},
+		});
+
+		const postId = await editor.publishPost();
+		await page.goto(`/?p=${postId}`);
+
+		const image = page.locator('.feedzy-rss .rss_image img');
+		await expect(image).toHaveAttribute('style', /aspect-ratio:\s*3\/2;/i);
+	});
+
+	test('check aspect ratio auto', async ({ editor, page, admin }) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'feedzy-rss-feeds/feedzy-block',
+			attributes: {
+				aspectRatio: 'auto',
+				feeds: 'https://www.nasa.gov/feeds/iotd-feed/',
+				max: 1,
+			},
+		});
+
+		const postId = await editor.publishPost();
+		await page.goto(`/?p=${postId}`);
+
+		const image = page.locator('.feedzy-rss .rss_image img');
+		await expect(image).toHaveAttribute('style', /aspect-ratio:\s*auto;/i);
+	});
+});


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added Aspect Ratio Options and Better Dimension Handling for thumbnail image control.
Inspired by WordPress Aspect Ratio's design.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
#### Editor
<img width="5094" height="2486" alt="CleanShot 2025-08-01 at 10 45 38@2x" src="https://github.com/user-attachments/assets/28f5083b-d1d2-40dc-9cb1-488e90b0ae09" />

#### Preview
<img width="5102" height="2478" alt="CleanShot 2025-07-31 at 16 31 21@2x" src="https://github.com/user-attachments/assets/b93abb3b-a180-4908-a09a-836d3914fe99" />

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Try to play with the Aspect Ratio selector.
- Also, check in an AMP environment

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/883
<!-- Should look like this: `Closes #1, #2, #3.` . -->
