### PR TITLE
refactor: improved fallback settings for importer

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -2563,6 +2563,26 @@ li.draggable-item .components-panel__body-toggle.components-button{
 	display: flex;
 	flex-wrap: wrap;
 	gap: 1em;
+	margin: 1em 0 1em;
+}
+.feedzy-wrap .fz-spacing{
+	margin: 1em 0 1em;
+}
+.fz-radio-label {
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 4px;
+}
+.fz-radio-description {
+    color: #666;
+    font-size: 13px;
+    line-height: 1.4;
+    display: block;
+}
+.fz-radio-title {
+	font-size: 16px;
+	font-weight: 600;
+	color: #050505;
 }
 
 @-webkit-keyframes spin { 

--- a/css/settings.css
+++ b/css/settings.css
@@ -2559,6 +2559,11 @@ li.draggable-item .components-panel__body-toggle.components-button{
 	border-bottom: 0;
     padding: 24px 0 0;
 }
+.fz-fallback-images {
+	display: flex;
+	gap: 1em;
+}
+
 @-webkit-keyframes spin { 
     100% { -webkit-transform: rotate(360deg); } 
 }

--- a/css/settings.css
+++ b/css/settings.css
@@ -2561,6 +2561,7 @@ li.draggable-item .components-panel__body-toggle.components-button{
 }
 .fz-fallback-images {
 	display: flex;
+	flex-wrap: wrap;
 	gap: 1em;
 }
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -524,16 +524,12 @@ class Feedzy_Rss_Feeds_Import {
 			$import_feed_limit = 10;
 		}
 
-		$default_thumbnail_id = 0;
+		$default_thumbnail_id   = 0;
+		$inherited_thumbnail_id = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 		if ( feedzy_is_pro() ) {
 			$default_thumbnail_id = get_post_meta( $post->ID, 'default_thumbnail_id', true );
-			if (
-				empty( $default_thumbnail_id ) &&
-				'0' !== $default_thumbnail_id // Can use the fallback image from Global Settings.
-			) {
-				$default_thumbnail_id = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
-			}
 		}
+
 		$import_schedule = array(
 			'fz_cron_schedule' => ! empty( $this->free_settings['general']['fz_cron_schedule'] ) ? $this->free_settings['general']['fz_cron_schedule'] : '',
 		);

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -792,20 +792,30 @@ global $post;
 										<a 
 											href="javascript:;" class="feedzy-open-media btn btn-outline-primary">
 											<?php 
-												echo esc_html( $btn_label );
+											echo esc_html( $btn_label );
 											?>
 										</a>
-										<a 
-											href="javascript:;" class="feedzy-remove-media btn btn-outline-primary 
-												<?php
-													echo ! empty( $valid_thumbnails_id ) ? esc_attr( 'is-show' ) : ''; 
+										<a href="javascript:;"
+											class="feedzy-remove-media btn btn-outline-primary 
+												<?php 
+												echo ! empty( $valid_thumbnail_ids ) ? esc_attr( 'is-show' ) : ''; 
 												?>
-										">
+												"
+										>
 											<?php
 												esc_html_e( 'Remove', 'feedzy-rss-feeds' ); 
 											?>
 										</a>
-										<input type="hidden" name="feedzy_meta_data[default_thumbnail_id]" id="feed-post-default-thumbnail" value="<?php echo esc_attr( $default_thumbnail_id ); ?>">
+										<input 
+											type="hidden" 
+											name="feedzy_meta_data[default_thumbnail_id]" 
+											id="feed-post-default-thumbnail" 
+											value="
+												<?php
+												echo esc_attr( implode( ',', $valid_thumbnail_ids ) );
+												?>
+												"
+										>
 									</div>
 								</div>
 								
@@ -1022,39 +1032,4 @@ global $post;
 
 <script id="new_field_tpl" type="text/template">
 	<?php echo wp_kses( apply_filters( 'feedzy_custom_field_template', '' ), apply_filters( 'feedzy_wp_kses_allowed_html', array() ) ); ?>
-</script>
-
-<script>
-jQuery(document).ready(function($) {
-	$('#use-inherited-thumbnail').on('change', function() {
-		if ($(this).is(':checked')) {
-			$('#custom-fallback-image-section').hide();
-			$('#inherited-fallback-image-section').show();
-			$('#feed-post-default-thumbnail').val('');
-		} else {
-			$('#custom-fallback-image-section').show();
-			$('#inherited-fallback-image-section').hide();
-		}
-	});
-	
-	$('.feedzy-remove-media').on('click', function() {
-		if ($('#use-inherited-thumbnail').length && $('#use-inherited-thumbnail').is(':checked')) {
-			return false;
-		}
-	});
-
-	$('input[name="feedzy_meta_data[fallback_image_option]"]').on('change', function() {
-		var selectedValue = $(this).val();
-		
-		if (selectedValue === 'custom') {
-			$('#custom-fallback-section').show();
-			$('#general-fallback-preview').hide();
-		} else {
-			$('#custom-fallback-section').hide();
-			$('#general-fallback-preview').show();
-		}
-	});
-
-	$('input[name="feedzy_meta_data[fallback_image_option]"]:checked').trigger('change');
-});
 </script>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -765,16 +765,20 @@ global $post;
 								<div id="custom-fallback-section" style="<?php echo 'custom' === $fallback_option ? '' : 'display: none;'; ?>">
 									<?php
 									$btn_label             = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
-									$default_thumbnails_id = isset( $default_thumbnail_id ) ? explode( ',', $default_thumbnail_id ) : array();
-									
-									if ( ! empty( $default_thumbnails_id ) ) :
+									$saved_fallback_thumbnail_ids = is_string( $default_thumbnail_id ) ? explode( ',', $default_thumbnail_id ) : array();
+									$valid_thumbnail_ids   = array_filter( $saved_fallback_thumbnail_ids, 'is_numeric' );
+									$valid_thumbnail_ids   = array_filter( $valid_thumbnail_ids, function ( $id ) {
+										return wp_attachment_is_image( $id );
+									} );
+								
+									if ( ! empty( $valid_thumbnail_ids ) ) :
 										$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
 										?>
 										<div class="fz-form-group mb-20 feedzy-media-preview ">
 											<label class="form-label"><?php esc_html_e( 'Custom fallback image for this feed:', 'feedzy-rss-feeds' ); ?></label>
 											<div class="fz-fallback-images">
 												<?php
-												foreach ( $default_thumbnails_id as $thumbnail_id ) {
+												foreach ( $valid_thumbnail_ids as $thumbnail_id ) {
 													echo wp_get_attachment_image( $thumbnail_id, 'thumbnail' );
 												}
 												?>
@@ -791,7 +795,7 @@ global $post;
 										<a 
 											href="javascript:;" class="feedzy-remove-media btn btn-outline-primary 
 												<?php
-													echo $default_thumbnail_id ? esc_attr( 'is-show' ) : ''; 
+													echo ! empty ( $valid_thumbnails_id ) ? esc_attr( 'is-show' ) : ''; 
 												?>
 										">
 											<?php

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -699,148 +699,183 @@ global $post;
 								</div>
 							</div>
 
-					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
-						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-image', 'import' ) ); ?>
-						<div class="fz-left">
-							<h4 class="h4"><?php esc_html_e( 'Fallback Image', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
-						</div>
-						<div class="fz-right">
-							<div class="fz-form-group">
-								<div class="form-label"><?php esc_html_e( 'Which fallback featured image should be used for this feed?', 'feedzy-rss-feeds' ); ?></div>
-								
-								<?php 
-								$fallback_option = ! empty( $default_thumbnail_id ) ? 'custom' : 'general';
-								?>
-								
-								<div class="fz-spacing">
-									<input type="radio" id="use-general-fallback" name="feedzy_meta_data[fallback_image_option]" value="general" <?php checked( $fallback_option, 'general' ); ?>>
-									<label for="use-general-fallback" class="fz-radio-label">
-										<strong class="fz-radio-title"><?php esc_html_e( 'Use general setting', 'feedzy-rss-feeds' ); ?></strong>
-										<br>
-										<span class="fz-radio-description"><?php esc_html_e( 'Updates automatically when the general fallback image changes.', 'feedzy-rss-feeds' ); ?></span>
-									</label>
+							<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
+								<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-image', 'import' ) ); ?>
+								<div class="fz-left">
+									<h4 class="h4">
+										<?php esc_html_e( 'Fallback Image', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?>
+									</h4>
 								</div>
-
-								<div id="general-fallback-preview" class="fz-spacing" style="<?php echo 'general' === $fallback_option ? '' : 'display: none;'; ?>">
-									<?php if ( ! empty( $inherited_thumbnail_id ) ) : ?>
-										<div class="fz-form-group">
-											<?php 
-											$image = wp_get_attachment_image( $inherited_thumbnail_id, 'thumbnail' );
-											if ( $image ) {
-												echo wp_kses_post( $image );
-											} else {
-												echo '<div class="help-text">' . esc_html__( 'General fallback image not found (may have been deleted)', 'feedzy-rss-feeds' ) . '</div>';
-											}
-											?>
+								<div class="fz-right">
+									<div class="fz-form-group">
+										<div class="form-label">
+											<?php esc_html_e( 'Which fallback featured image should be used for this feed?', 'feedzy-rss-feeds' ); ?>
 										</div>
-									<?php else : ?>
-										<div class="fz-form-group mb-20">
-											<div class="help-text">
-												<?php 
-												echo wp_kses_post(
-													__( 'No general fallback image set. ', 'feedzy-rss-feeds' )
-												);
-												?>
-											</div>
-										</div>
-									<?php endif; ?>
-									
-									<div class="help-text pt-8">
+										
 										<?php 
-										echo wp_kses_post( 
-											sprintf(
-												/* translators: %s is replaced with a link to the Feedzy Settings page */
-												__( 'You can update the general fallback image in %s.', 'feedzy-rss-feeds' ),
-												'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
-											) 
-										); 
+										$fallback_option = ! empty( $default_thumbnail_id ) ? 'custom' : 'general';
 										?>
-									</div>
-								</div>
-								
-								<div class="fz-spacing">
-									<input type="radio" id="use-custom-fallback" name="feedzy_meta_data[fallback_image_option]" value="custom" <?php checked( $fallback_option, 'custom' ); ?>>
-									<label for="use-custom-fallback" class="fz-radio-label">
-										<strong class="fz-radio-title"><?php esc_html_e( 'Add custom fallback image', 'feedzy-rss-feeds' ); ?></strong>
-										<br>
-										<span class="fz-radio-description small"><?php esc_html_e( 'Use a specific image just for this feed.', 'feedzy-rss-feeds' ); ?></span>
-									</label>
-								</div>
+										
+										<div class="fz-spacing">
+											<input
+												type="radio"
+												id="use-general-fallback"
+												name="feedzy_meta_data[fallback_image_option]"
+												value="general"
+												<?php checked( $fallback_option, 'general' ); ?>
+											>
+											<label for="use-general-fallback" class="fz-radio-label">
+												<strong class="fz-radio-title">
+													<?php esc_html_e( 'Use general setting', 'feedzy-rss-feeds' ); ?>
+												</strong>
+												<br>
+												<span class="fz-radio-description">
+													<?php esc_html_e( 'Updates automatically when the general fallback image changes.', 'feedzy-rss-feeds' ); ?>
+												</span>
+											</label>
+										</div>
 
-								<div id="custom-fallback-section" style="<?php echo 'custom' === $fallback_option ? '' : 'display: none;'; ?>">
-									<?php
-									$btn_label                    = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
-									$saved_fallback_thumbnail_ids = is_string( $default_thumbnail_id ) ? explode( ',', $default_thumbnail_id ) : array();
-									$valid_thumbnail_ids          = array_filter( $saved_fallback_thumbnail_ids, 'is_numeric' );
-									$valid_thumbnail_ids          = array_filter(
-										$valid_thumbnail_ids,
-										function ( $id ) {
-											return wp_attachment_is_image( intval( $id ) );
-										} 
-									);
-								
-									if ( ! empty( $valid_thumbnail_ids ) ) :
-										$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
-										?>
-										<div class="fz-form-group feedzy-media-preview ">
-											<div class="fz-fallback-images">
-												<?php
-												foreach ( $valid_thumbnail_ids as $thumbnail_id ) {
-													echo wp_get_attachment_image( $thumbnail_id, 'thumbnail' );
-												}
+										<div
+											id="general-fallback-preview"
+											class="fz-spacing"
+											style="<?php echo 'general' === $fallback_option ? '' : 'display: none;'; ?>"
+										>
+											<?php if ( ! empty( $inherited_thumbnail_id ) ) : ?>
+												<div class="fz-form-group">
+													<?php 
+													$image = wp_get_attachment_image( $inherited_thumbnail_id, 'thumbnail' );
+													if ( $image ) {
+														echo wp_kses_post( $image );
+													} else {
+														echo '<div class="help-text">' . esc_html__( 'General fallback image not found (may have been deleted)', 'feedzy-rss-feeds' ) . '</div>';
+													}
+													?>
+												</div>
+											<?php else : ?>
+												<div class="fz-form-group mb-20">
+													<div class="help-text">
+														<?php 
+														echo wp_kses_post(
+															__( 'No general fallback image set. ', 'feedzy-rss-feeds' )
+														);
+														?>
+													</div>
+												</div>
+											<?php endif; ?>
+											
+											<div class="help-text pt-8">
+												<?php 
+												echo wp_kses_post( 
+													sprintf(
+														/* translators: %s is replaced with a link to the Feedzy Settings page */
+														__( 'You can update the general fallback image in %s.', 'feedzy-rss-feeds' ),
+														'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
+													) 
+												); 
 												?>
 											</div>
 										</div>
-									<?php endif; ?>
+										
+										<div class="fz-spacing">
+											<input
+												type="radio"
+												id="use-custom-fallback"
+												name="feedzy_meta_data[fallback_image_option]"
+												value="custom"
+												<?php checked( $fallback_option, 'custom' ); ?>
+											>
+											<label for="use-custom-fallback" class="fz-radio-label">
+												<strong class="fz-radio-title">
+													<?php esc_html_e( 'Add custom fallback image', 'feedzy-rss-feeds' ); ?>
+												</strong>
+												<br>
+												<span class="fz-radio-description small">
+													<?php esc_html_e( 'Use a specific image just for this feed.', 'feedzy-rss-feeds' ); ?>
+												</span>
+											</label>
+										</div>
 
-									<div class="fz-cta-group pb-8">
-										<a 
-											href="javascript:;" class="feedzy-open-media btn btn-outline-primary">
-											<?php 
-											echo esc_html( $btn_label );
-											?>
-										</a>
-										<a href="javascript:;"
-											class="feedzy-remove-media btn btn-outline-primary 
-												<?php 
-												echo ! empty( $valid_thumbnail_ids ) ? esc_attr( 'is-show' ) : ''; 
-												?>
-												"
+										<div
+											id="custom-fallback-section"
+											style="<?php echo 'custom' === $fallback_option ? '' : 'display: none;'; ?>"
 										>
 											<?php
-												esc_html_e( 'Remove', 'feedzy-rss-feeds' ); 
-											?>
-										</a>
-										<input 
-											type="hidden" 
-											name="feedzy_meta_data[default_thumbnail_id]" 
-											id="feed-post-default-thumbnail" 
-											value="
-												<?php
-												echo esc_attr( implode( ',', $valid_thumbnail_ids ) );
+											$btn_label                    = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
+											$saved_fallback_thumbnail_ids = is_string( $default_thumbnail_id ) ? explode( ',', $default_thumbnail_id ) : array();
+											$valid_thumbnail_ids          = array_filter( $saved_fallback_thumbnail_ids, 'is_numeric' );
+											$valid_thumbnail_ids          = array_filter(
+												$valid_thumbnail_ids,
+												function ( $id ) {
+													return wp_attachment_is_image( intval( $id ) );
+												} 
+											);
+										
+											if ( ! empty( $valid_thumbnail_ids ) ) :
+												$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
 												?>
-												"
-										>
+												<div class="fz-form-group feedzy-media-preview ">
+													<div class="fz-fallback-images">
+														<?php
+														foreach ( $valid_thumbnail_ids as $thumbnail_id ) {
+															echo wp_get_attachment_image( $thumbnail_id, 'thumbnail' );
+														}
+														?>
+													</div>
+												</div>
+											<?php endif; ?>
+
+											<div class="fz-cta-group pb-8">
+												<a 
+													href="javascript:;"
+													class="feedzy-open-media btn btn-outline-primary"
+												>
+													<?php 
+													echo esc_html( $btn_label );
+													?>
+												</a>
+												<a
+													href="javascript:;"
+													class="feedzy-remove-media btn btn-outline-primary <?php echo ! empty( $valid_thumbnail_ids ) ? esc_attr( 'is-show' ) : ''; ?>"
+												>
+													<?php esc_html_e( 'Remove', 'feedzy-rss-feeds' ); ?>
+												</a>
+												<input 
+													type="hidden" 
+													name="feedzy_meta_data[default_thumbnail_id]" 
+													id="feed-post-default-thumbnail" 
+													value="<?php echo esc_attr( implode( ',', $valid_thumbnail_ids ) ); ?>"
+												>
+											</div>
+										</div>
+									</div>
+									<div class="help-text pt-8">
+										<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image during the import process.', 'feedzy-rss-feeds' ); ?>
 									</div>
 								</div>
-							</div>
-							<div class="help-text pt-8">
-								<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image during the import process.', 'feedzy-rss-feeds' ); ?>
 							</div>
 						</div>
 					</div>
+					<div class="fz-tab-content" id="fz-advanced-settings">
+						<div class="fz-form-wrap">
 
 							<div class="form-block form-block-two-column no-border">
 								<div class="fz-left">
-									<h4 class="h4"><?php esc_html_e( 'Remove Duplicates', 'feedzy-rss-feeds' ); ?></h4>
+									<h4 class="h4">
+										<?php esc_html_e( 'Remove Duplicates', 'feedzy-rss-feeds' ); ?>
+									</h4>
 								</div>
 								<div class="fz-right">
 									<div class="fz-form-group">
 										<div class="fz-form-switch">
-											<input id="remove-duplicates" name="feedzy_meta_data[import_remove_duplicates]"
-													class="fz-switch-toggle" type="checkbox" value="yes"
-												<?php echo esc_attr( $import_remove_duplicates ); ?>>
-											<label class="feedzy-inline form-label" for="remove-duplicates"><?php esc_html_e( 'Remove Duplicate Items', 'feedzy-rss-feeds' ); ?></label>
+											<input
+												id="remove-duplicates"
+												name="feedzy_meta_data[import_remove_duplicates]"
+												class="fz-switch-toggle" type="checkbox" value="yes"
+												<?php echo esc_attr( $import_remove_duplicates ); ?>
+											>
+											<label class="feedzy-inline form-label" for="remove-duplicates">
+												<?php esc_html_e( 'Remove Duplicate Items', 'feedzy-rss-feeds' ); ?>
+											</label>
 										</div>
 									</div>
 									<div class="help-text">

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -764,12 +764,15 @@ global $post;
 								<!-- Custom fallback section -->
 								<div id="custom-fallback-section" style="<?php echo 'custom' === $fallback_option ? '' : 'display: none;'; ?>">
 									<?php
-									$btn_label             = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
+									$btn_label                    = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
 									$saved_fallback_thumbnail_ids = is_string( $default_thumbnail_id ) ? explode( ',', $default_thumbnail_id ) : array();
-									$valid_thumbnail_ids   = array_filter( $saved_fallback_thumbnail_ids, 'is_numeric' );
-									$valid_thumbnail_ids   = array_filter( $valid_thumbnail_ids, function ( $id ) {
-										return wp_attachment_is_image( $id );
-									} );
+									$valid_thumbnail_ids          = array_filter( $saved_fallback_thumbnail_ids, 'is_numeric' );
+									$valid_thumbnail_ids          = array_filter(
+										$valid_thumbnail_ids,
+										function ( $id ) {
+											return wp_attachment_is_image( intval( $id ) );
+										} 
+									);
 								
 									if ( ! empty( $valid_thumbnail_ids ) ) :
 										$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
@@ -795,7 +798,7 @@ global $post;
 										<a 
 											href="javascript:;" class="feedzy-remove-media btn btn-outline-primary 
 												<?php
-													echo ! empty ( $valid_thumbnails_id ) ? esc_attr( 'is-show' ) : ''; 
+													echo ! empty( $valid_thumbnails_id ) ? esc_attr( 'is-show' ) : ''; 
 												?>
 										">
 											<?php

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -699,52 +699,127 @@ global $post;
 								</div>
 							</div>
 
-							<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
-								<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-image', 'import' ) ); ?>
-								<div class="fz-left">
-									<h4 class="h4"><?php esc_html_e( 'Fallback Image', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
+					<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
+						<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'fallback-image', 'import' ) ); ?>
+						<div class="fz-left">
+							<h4 class="h4"><?php esc_html_e( 'Fallback Image', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
+						</div>
+						<div class="fz-right">
+							<div class="fz-form-group">
+								<label class="form-label"><?php esc_html_e( 'Which fallback featured image should be used for this feed?', 'feedzy-rss-feeds' ); ?></label>
+								
+								<?php 
+								$fallback_option = ! empty( $default_thumbnail_id ) ? 'custom' : 'general';
+								?>
+								
+								<div class="fz-fallback-options mb-20">
+									<div class="fz-radio-option">
+										<input type="radio" id="use-general-fallback" name="feedzy_meta_data[fallback_image_option]" value="general" <?php checked( $fallback_option, 'general' ); ?>>
+										<label for="use-general-fallback" class="fz-radio-label">
+											<strong><?php esc_html_e( 'Use general setting', 'feedzy-rss-feeds' ); ?></strong>
+											<span class="fz-radio-description"><?php esc_html_e( 'Updates automatically when the general fallback image changes.', 'feedzy-rss-feeds' ); ?></span>
+										</label>
+									</div>
+									
+									<div class="fz-radio-option">
+										<input type="radio" id="use-custom-fallback" name="feedzy_meta_data[fallback_image_option]" value="custom" <?php checked( $fallback_option, 'custom' ); ?>>
+										<label for="use-custom-fallback" class="fz-radio-label">
+											<strong><?php esc_html_e( 'Add custom fallback image', 'feedzy-rss-feeds' ); ?></strong>
+											<span class="fz-radio-description"><?php esc_html_e( 'Use a specific image just for this feed.', 'feedzy-rss-feeds' ); ?></span>
+										</label>
+									</div>
 								</div>
-								<div class="fz-right">
-									<div class="fz-form-group">
-										<label class="form-label"><?php esc_html_e( 'Select an image to be the fallback featured image.', 'feedzy-rss-feeds' ); ?></label>
-										<?php
-										$btn_label            = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
-										$default_thumbnail_id = ! empty( $default_thumbnail_id ) ? explode( ',', (string) $default_thumbnail_id ) : array();
-										if ( ! empty( $default_thumbnail_id ) ) :
-											$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
+
+								<!-- General fallback preview -->
+								<div id="general-fallback-preview" style="<?php echo 'general' === $fallback_option ? '' : 'display: none;'; ?>">
+									<?php if ( ! empty( $inherited_thumbnail_id ) ) : ?>
+										<div class="fz-form-group mb-20">
+											<label class="form-label"><?php esc_html_e( 'Current general fallback image:', 'feedzy-rss-feeds' ); ?></label>
+											<?php 
+											$image = wp_get_attachment_image( $inherited_thumbnail_id, 'thumbnail' );
+											if ( $image ) {
+												echo wp_kses_post( $image );
+											} else {
+												echo '<div class="help-text">' . esc_html__( 'General fallback image not found (may have been deleted)', 'feedzy-rss-feeds' ) . '</div>';
+											}
 											?>
-											<div class="fz-form-group mb-20 feedzy-media-preview">
+										</div>
+									<?php else : ?>
+										<div class="fz-form-group mb-20">
+											<div class="help-text">
+												<?php 
+												echo wp_kses_post( 
+													sprintf( 
+														/* translators: %s: opening anchor tag, %s: closing anchor tag */
+														__( 'No general fallback image set. %s', 'feedzy-rss-feeds' ),
+														'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Set one in Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
+													) 
+												); 
+												?>
+											</div>
+										</div>
+									<?php endif; ?>
+								</div>
+
+								<!-- Custom fallback section -->
+								<div id="custom-fallback-section" style="<?php echo 'custom' === $fallback_option ? '' : 'display: none;'; ?>">
+									<?php
+									$btn_label             = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
+									$default_thumbnails_id = isset( $default_thumbnail_id ) ? explode( ',', $default_thumbnail_id ) : array();
+									
+									if ( ! empty( $default_thumbnails_id ) ) :
+										$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
+										?>
+										<div class="fz-form-group mb-20 feedzy-media-preview ">
+											<label class="form-label"><?php esc_html_e( 'Custom fallback image for this feed:', 'feedzy-rss-feeds' ); ?></label>
+											<div class="fz-fallback-images">
 												<?php
-												if ( count( $default_thumbnail_id ) > 1 ) {
-													?>
-													<a href="javascript:;" class="btn btn-outline-primary feedzy-images-selected">
-														<?php
-														// translators: %d select images count.
-														echo esc_html( sprintf( __( '(%d) images selected', 'feedzy-rss-feeds' ), count( $default_thumbnail_id ) ) );
-														?>
-													</a>
-													<?php
-												} else {
-													echo wp_get_attachment_image( reset( $default_thumbnail_id ), 'thumbnail' );
+												foreach ( $default_thumbnails_id as $thumbnail_id ) {
+													echo wp_get_attachment_image( $thumbnail_id, 'thumbnail' );
 												}
 												?>
 											</div>
-										<?php endif; ?>
-										<div class="fz-cta-group pb-8">
-											<a href="javascript:;" class="feedzy-open-media btn btn-outline-primary"><?php echo esc_html( $btn_label ); ?></a>
-											<a href="javascript:;" class="feedzy-remove-media btn btn-outline-primary <?php echo ! empty( $default_thumbnail_id ) ? esc_attr( 'is-show' ) : ''; ?>"><?php esc_html_e( 'Remove', 'feedzy-rss-feeds' ); ?></a>
-											<input type="hidden" name="feedzy_meta_data[default_thumbnail_id]" id="feed-post-default-thumbnail" value="<?php echo esc_attr( implode( ',', $default_thumbnail_id ) ); ?>">
 										</div>
-										<div class="help-text pt-8">
-											<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image. If multiple fallback images are selected, one of them will be randomly assigned to each post without an image during the import process.', 'feedzy-rss-feeds' ); ?>
-										</div>
+									<?php endif; ?>
+									<div class="fz-cta-group pb-8">
+										<a 
+											href="javascript:;" class="feedzy-open-media btn btn-outline-primary">
+											<?php 
+												echo esc_html( $btn_label );
+											?>
+										</a>
+										<a 
+											href="javascript:;" class="feedzy-remove-media btn btn-outline-primary 
+												<?php
+													echo $default_thumbnail_id ? esc_attr( 'is-show' ) : ''; 
+												?>
+										">
+											<?php
+												esc_html_e( 'Remove', 'feedzy-rss-feeds' ); 
+											?>
+										</a>
+										<input type="hidden" name="feedzy_meta_data[default_thumbnail_id]" id="feed-post-default-thumbnail" value="<?php echo esc_attr( $default_thumbnail_id ); ?>">
 									</div>
+								</div>
+								
+								<div class="help-text pt-8">
+									<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image during the import process.', 'feedzy-rss-feeds' ); ?>
+								</div>
+								
+								<div class="help-text pt-8">
+									<?php 
+									echo wp_kses_post( 
+										sprintf(
+											/* translators: %s: opening anchor tag, %s: closing anchor tag */ 
+											__( 'You can update the general fallback image in %s.', 'feedzy-rss-feeds' ),
+											'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
+										) 
+									); 
+									?>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div class="fz-tab-content" id="fz-advanced-settings">
-						<div class="fz-form-wrap">
 
 							<div class="form-block form-block-two-column no-border">
 								<div class="fz-left">
@@ -940,4 +1015,39 @@ global $post;
 
 <script id="new_field_tpl" type="text/template">
 	<?php echo wp_kses( apply_filters( 'feedzy_custom_field_template', '' ), apply_filters( 'feedzy_wp_kses_allowed_html', array() ) ); ?>
+</script>
+
+<script>
+jQuery(document).ready(function($) {
+	$('#use-inherited-thumbnail').on('change', function() {
+		if ($(this).is(':checked')) {
+			$('#custom-fallback-image-section').hide();
+			$('#inherited-fallback-image-section').show();
+			$('#feed-post-default-thumbnail').val('');
+		} else {
+			$('#custom-fallback-image-section').show();
+			$('#inherited-fallback-image-section').hide();
+		}
+	});
+	
+	$('.feedzy-remove-media').on('click', function() {
+		if ($('#use-inherited-thumbnail').length && $('#use-inherited-thumbnail').is(':checked')) {
+			return false;
+		}
+	});
+
+	$('input[name="feedzy_meta_data[fallback_image_option]"]').on('change', function() {
+		var selectedValue = $(this).val();
+		
+		if (selectedValue === 'custom') {
+			$('#custom-fallback-section').show();
+			$('#general-fallback-preview').hide();
+		} else {
+			$('#custom-fallback-section').hide();
+			$('#general-fallback-preview').show();
+		}
+	});
+
+	$('input[name="feedzy_meta_data[fallback_image_option]"]:checked').trigger('change');
+});
 </script>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -737,13 +737,9 @@ global $post;
 										<div class="fz-form-group mb-20">
 											<div class="help-text">
 												<?php 
-												echo wp_kses_post( 
-													sprintf( 
-														/* translators: %s: opening anchor tag, %s: closing anchor tag */
-														__( 'No general fallback image set. %s', 'feedzy-rss-feeds' ),
-														'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Set one in Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
-													) 
-												); 
+												echo wp_kses_post(
+													__( 'No general fallback image set. ', 'feedzy-rss-feeds' )
+												);
 												?>
 											</div>
 										</div>
@@ -753,7 +749,7 @@ global $post;
 										<?php 
 										echo wp_kses_post( 
 											sprintf(
-												/* translators: %s: opening anchor tag, %s: closing anchor tag */ 
+												/* translators: %s is replaced with a link to the Feedzy Settings page */
 												__( 'You can update the general fallback image in %s.', 'feedzy-rss-feeds' ),
 												'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
 											) 

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -706,35 +706,24 @@ global $post;
 						</div>
 						<div class="fz-right">
 							<div class="fz-form-group">
-								<label class="form-label"><?php esc_html_e( 'Which fallback featured image should be used for this feed?', 'feedzy-rss-feeds' ); ?></label>
+								<div class="form-label"><?php esc_html_e( 'Which fallback featured image should be used for this feed?', 'feedzy-rss-feeds' ); ?></div>
 								
 								<?php 
 								$fallback_option = ! empty( $default_thumbnail_id ) ? 'custom' : 'general';
 								?>
 								
-								<div class="fz-fallback-options mb-20">
-									<div class="fz-radio-option">
-										<input type="radio" id="use-general-fallback" name="feedzy_meta_data[fallback_image_option]" value="general" <?php checked( $fallback_option, 'general' ); ?>>
-										<label for="use-general-fallback" class="fz-radio-label">
-											<strong><?php esc_html_e( 'Use general setting', 'feedzy-rss-feeds' ); ?></strong>
-											<span class="fz-radio-description"><?php esc_html_e( 'Updates automatically when the general fallback image changes.', 'feedzy-rss-feeds' ); ?></span>
-										</label>
-									</div>
-									
-									<div class="fz-radio-option">
-										<input type="radio" id="use-custom-fallback" name="feedzy_meta_data[fallback_image_option]" value="custom" <?php checked( $fallback_option, 'custom' ); ?>>
-										<label for="use-custom-fallback" class="fz-radio-label">
-											<strong><?php esc_html_e( 'Add custom fallback image', 'feedzy-rss-feeds' ); ?></strong>
-											<span class="fz-radio-description"><?php esc_html_e( 'Use a specific image just for this feed.', 'feedzy-rss-feeds' ); ?></span>
-										</label>
-									</div>
+								<div class="fz-spacing">
+									<input type="radio" id="use-general-fallback" name="feedzy_meta_data[fallback_image_option]" value="general" <?php checked( $fallback_option, 'general' ); ?>>
+									<label for="use-general-fallback" class="fz-radio-label">
+										<strong class="fz-radio-title"><?php esc_html_e( 'Use general setting', 'feedzy-rss-feeds' ); ?></strong>
+										<br>
+										<span class="fz-radio-description"><?php esc_html_e( 'Updates automatically when the general fallback image changes.', 'feedzy-rss-feeds' ); ?></span>
+									</label>
 								</div>
 
-								<!-- General fallback preview -->
-								<div id="general-fallback-preview" style="<?php echo 'general' === $fallback_option ? '' : 'display: none;'; ?>">
+								<div id="general-fallback-preview" class="fz-spacing" style="<?php echo 'general' === $fallback_option ? '' : 'display: none;'; ?>">
 									<?php if ( ! empty( $inherited_thumbnail_id ) ) : ?>
-										<div class="fz-form-group mb-20">
-											<label class="form-label"><?php esc_html_e( 'Current general fallback image:', 'feedzy-rss-feeds' ); ?></label>
+										<div class="fz-form-group">
 											<?php 
 											$image = wp_get_attachment_image( $inherited_thumbnail_id, 'thumbnail' );
 											if ( $image ) {
@@ -759,9 +748,29 @@ global $post;
 											</div>
 										</div>
 									<?php endif; ?>
+									
+									<div class="help-text pt-8">
+										<?php 
+										echo wp_kses_post( 
+											sprintf(
+												/* translators: %s: opening anchor tag, %s: closing anchor tag */ 
+												__( 'You can update the general fallback image in %s.', 'feedzy-rss-feeds' ),
+												'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
+											) 
+										); 
+										?>
+									</div>
+								</div>
+								
+								<div class="fz-spacing">
+									<input type="radio" id="use-custom-fallback" name="feedzy_meta_data[fallback_image_option]" value="custom" <?php checked( $fallback_option, 'custom' ); ?>>
+									<label for="use-custom-fallback" class="fz-radio-label">
+										<strong class="fz-radio-title"><?php esc_html_e( 'Add custom fallback image', 'feedzy-rss-feeds' ); ?></strong>
+										<br>
+										<span class="fz-radio-description small"><?php esc_html_e( 'Use a specific image just for this feed.', 'feedzy-rss-feeds' ); ?></span>
+									</label>
 								</div>
 
-								<!-- Custom fallback section -->
 								<div id="custom-fallback-section" style="<?php echo 'custom' === $fallback_option ? '' : 'display: none;'; ?>">
 									<?php
 									$btn_label                    = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
@@ -777,8 +786,7 @@ global $post;
 									if ( ! empty( $valid_thumbnail_ids ) ) :
 										$btn_label = esc_html__( 'Replace image', 'feedzy-rss-feeds' );
 										?>
-										<div class="fz-form-group mb-20 feedzy-media-preview ">
-											<label class="form-label"><?php esc_html_e( 'Custom fallback image for this feed:', 'feedzy-rss-feeds' ); ?></label>
+										<div class="fz-form-group feedzy-media-preview ">
 											<div class="fz-fallback-images">
 												<?php
 												foreach ( $valid_thumbnail_ids as $thumbnail_id ) {
@@ -788,6 +796,7 @@ global $post;
 											</div>
 										</div>
 									<?php endif; ?>
+
 									<div class="fz-cta-group pb-8">
 										<a 
 											href="javascript:;" class="feedzy-open-media btn btn-outline-primary">
@@ -818,22 +827,9 @@ global $post;
 										>
 									</div>
 								</div>
-								
-								<div class="help-text pt-8">
-									<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image during the import process.', 'feedzy-rss-feeds' ); ?>
-								</div>
-								
-								<div class="help-text pt-8">
-									<?php 
-									echo wp_kses_post( 
-										sprintf(
-											/* translators: %s: opening anchor tag, %s: closing anchor tag */ 
-											__( 'You can update the general fallback image in %s.', 'feedzy-rss-feeds' ),
-											'<a href="' . esc_url( admin_url( 'admin.php?page=feedzy-settings' ) ) . '" target="_blank">' . esc_html__( 'Feedzy Settings', 'feedzy-rss-feeds' ) . '</a>'
-										) 
-									); 
-									?>
-								</div>
+							</div>
+							<div class="help-text pt-8">
+								<?php esc_html_e( 'Helpful for setting a fallback image for feed items without an image during the import process.', 'feedzy-rss-feeds' ); ?>
 							</div>
 						</div>
 					</div>

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -3,136 +3,143 @@
  * import-metabox-edit.js
  *
  * @since	1.2.0
- * @package feedzy-rss-feeds-pro
+ * @package
  */
 /* global jQuery, ajaxurl, feedzy, tb_show */
 (function ($) {
 	function scroll_to_class(element_class, removed_height) {
-		var scroll_to = $(element_class).offset().top - removed_height;
+		const scroll_to = $(element_class).offset().top - removed_height;
 		if ($(window).scrollTop() !== scroll_to) {
-			$("html, body").stop().animate({ scrollTop: scroll_to }, 0);
+			$('html, body').stop().animate({ scrollTop: scroll_to }, 0);
 		}
 	}
 
 	function bar_progress(progress_line_object, direction) {
-		var number_of_steps = progress_line_object.data("number-of-steps");
-		var now_value = progress_line_object.data("now-value");
-		var new_value = 0;
-		if (direction === "right") {
+		const number_of_steps = progress_line_object.data('number-of-steps');
+		const now_value = progress_line_object.data('now-value');
+		let new_value = 0;
+		if (direction === 'right') {
 			new_value = now_value + 100 / number_of_steps;
-		} else if (direction === "left") {
+		} else if (direction === 'left') {
 			new_value = now_value - 100 / number_of_steps;
 		}
 		progress_line_object
-			.attr("style", "width: " + new_value + "%;")
-			.data("now-value", new_value);
+			.attr('style', 'width: ' + new_value + '%;')
+			.data('now-value', new_value);
 	}
 
 	function add_source() {
-		var field_name = $(this).data("field-name");
-		var field_tag = $(this).data("field-tag");
-		$('[name="feedzy_meta_data[' + field_name + ']"]').data('tagify')
+		const field_name = $(this).data('field-name');
+		const field_tag = $(this).data('field-tag');
+		$('[name="feedzy_meta_data[' + field_name + ']"]')
+			.data('tagify')
 			.addTags(field_tag);
-		$('[data-toggle="dropdown"]').parent().removeClass("open");
+		$('[data-toggle="dropdown"]').parent().removeClass('open');
 		$('[name="feedzy_meta_data[' + field_name + ']"]').focus();
 		return false;
 	}
 
 	function append_outside_tag() {
-		var outsideWrap = $( this ).parents( '.fz-form-group, .fz-input-group' );
-		var tags = outsideWrap.find( '.form-control' ).val();
+		const outsideWrap = $(this).parents('.fz-form-group, .fz-input-group');
+		const tags = outsideWrap.find('.form-control').val();
 
-		if ( '' === tags ) {
+		if ('' === tags) {
 			return false;
 		}
 
-		outsideWrap.find( '.form-control .tag-list' )?.val('');
-		if ( outsideWrap.next( '.tag-list' ).length > 0 ) {
-			outsideWrap.
-			next( '.tag-list' )
-			.find( 'input.fz-tagify-outside, input.fz-tagify--outside' )
-			.data('tagify')
-			.addTags( tags );
+		outsideWrap.find('.form-control .tag-list')?.val('');
+		if (outsideWrap.next('.tag-list').length > 0) {
+			outsideWrap
+				.next('.tag-list')
+				.find('input.fz-tagify-outside, input.fz-tagify--outside')
+				.data('tagify')
+				.addTags(tags);
 		} else {
-			outsideWrap.find( 'input.fz-tagify-outside, input.fz-tagify--outside' )
-			.data('tagify')
-			.addTags( tags );
+			outsideWrap
+				.find('input.fz-tagify-outside, input.fz-tagify--outside')
+				.data('tagify')
+				.addTags(tags);
 		}
 		return false;
 	}
 
 	function append_tag() {
-		var field_name = $(this).data("field-name");
-		var field_tag = $(this).data("field-tag");
-		if (field_name === "import_post_date" || field_name === "import_post_featured_img") {
-			$('[name="feedzy_meta_data[' + field_name + ']"]').data('tagify').removeAllTags();
-			$('[name="feedzy_meta_data[' + field_name + ']"]').data('tagify').addTags(
-				"[#" + field_tag + "]"
-			);
-		} else if( field_name === "import_post_content" ) {
+		const field_name = $(this).data('field-name');
+		const field_tag = $(this).data('field-tag');
+		if (
+			field_name === 'import_post_date' ||
+			field_name === 'import_post_featured_img'
+		) {
+			$('[name="feedzy_meta_data[' + field_name + ']"]')
+				.data('tagify')
+				.removeAllTags();
+			$('[name="feedzy_meta_data[' + field_name + ']"]')
+				.data('tagify')
+				.addTags('[#' + field_tag + ']');
+		} else if (field_name === 'import_post_content') {
 			$('[name="feedzy_meta_data[' + field_name + ']"]').focus();
-			$('[name="feedzy_meta_data[' + field_name + ']"]').data('tagify').addTags(
-				"[#" + field_tag + "]"
-			);
+			$('[name="feedzy_meta_data[' + field_name + ']"]')
+				.data('tagify')
+				.addTags('[#' + field_tag + ']');
 			return false;
 		} else {
-			$('[name="feedzy_meta_data[' + field_name + ']"]').data('tagify').addTags(
-				"[#" + field_tag + "]"
-			);
+			$('[name="feedzy_meta_data[' + field_name + ']"]')
+				.data('tagify')
+				.addTags('[#' + field_tag + ']');
 		}
-		$('[data-toggle="dropdown"]').parent().removeClass("open");
+		$('[data-toggle="dropdown"]').parent().removeClass('open');
 		$('[name="feedzy_meta_data[' + field_name + ']"]').focus();
 		return false;
 	}
 
 	function remove_row() {
-		$(this).closest(".key-value-item").remove();
+		$(this).closest('.key-value-item').remove();
 		return false;
 	}
 
 	function new_row() {
-		var html_row = "";
-		html_row = $("#new_field_tpl").html();
-		$(".custom_fields").append(html_row);
-		$(".btn.btn-remove-fields").on("click", remove_row);
+		let html_row = '';
+		html_row = $('#new_field_tpl').html();
+		$('.custom_fields').append(html_row);
+		$('.btn.btn-remove-fields').on('click', remove_row);
 		initCustomFieldAutoComplete();
 		document.dispatchEvent(new Event('feedzy_new_row_added'));
 		return false;
 	}
 
 	function update_status() {
-		var toggle = $(this);
-		var post_id = $(this).val();
-		var status = $(this).is(":checked");
+		const toggle = $(this);
+		const post_id = $(this).val();
+		const status = $(this).is(':checked');
 
-		var data = {
+		const data = {
 			security: feedzy.ajax.security,
-			action: "feedzy",
-			_action: "import_status",
+			action: 'feedzy',
+			_action: 'import_status',
 			id: post_id,
-			status: status,
+			status,
 		};
 
 		showSpinner(toggle);
 		$.ajax({
 			url: ajaxurl,
-			data: data,
-			method: "POST",
-			success: function (data) {
+			data,
+			method: 'POST',
+			success(data) {
 				if (!data.success && status) {
 					toggle
-						.parents("tr")
-						.find("td.feedzy-source")
-						.find(".feedzy-error-critical")
+						.parents('tr')
+						.find('td.feedzy-source')
+						.find('.feedzy-error-critical')
 						.remove();
 					toggle
-						.parents("tr")
-						.find("td.feedzy-source")
+						.parents('tr')
+						.find('td.feedzy-source')
 						.append($(data.data.msg));
-					toggle.prop("checked", false);
+					toggle.prop('checked', false);
 				}
 			},
-			complete: function () {
+			complete() {
 				hideSpinner(toggle);
 			},
 		});
@@ -140,15 +147,19 @@
 	}
 
 	function toggle_dropdown() {
-		$( '.dropdown.open' ).not( $(this).parent() ).removeClass( 'open' );
-		$(this).parent().toggleClass("open");
+		$('.dropdown.open').not($(this).parent()).removeClass('open');
+		$(this).parent().toggleClass('open');
 	}
 
 	function in_array($key, $array) {
-		if (typeof $array === "undefined" || $array.length === 0 || $key === "") {
+		if (
+			typeof $array === 'undefined' ||
+			$array.length === 0 ||
+			$key === ''
+		) {
 			return false;
 		}
-		for (var i = 0; i < $array.length; i++) {
+		for (let i = 0; i < $array.length; i++) {
 			if ($array[i] === $key) {
 				return true;
 			}
@@ -157,86 +168,116 @@
 	}
 
 	function update_taxonomy() {
-		var selected = $(this).val();
-		var tax_selected = $(this).data("tax");
-		if (typeof tax_selected !== "undefined") {
-			tax_selected = tax_selected.split(",");
+		const selected = $(this).val();
+		let tax_selected = $(this).data('tax');
+		if (typeof tax_selected !== 'undefined') {
+			tax_selected = tax_selected.split(',');
 		} else {
-			tax_selected = "";
+			tax_selected = '';
 		}
 
-		var data = {
+		const data = {
 			security: feedzy.ajax.security,
-			action: "feedzy",
-			_action: "get_taxonomies",
+			action: 'feedzy',
+			_action: 'get_taxonomies',
 			post_type: selected,
 		};
 
-		$("#feedzy_post_terms")
-			.html($("#loading_select_tpl").html())
-			.trigger("chosen:updated");
+		$('#feedzy_post_terms')
+			.html($('#loading_select_tpl').html())
+			.trigger('chosen:updated');
 
-		$.post(ajaxurl, data, function (response) {
-			var show_terms = true;
+		$.post(
+			ajaxurl,
+			data,
+			function (response) {
+				let show_terms = true;
 
-			var options = "";
-			if (response.length !== 0) {
-				$.each(response, function (index, terms) {
-					if (terms) {
-						var groupName = index;
-						if ( 'category' === groupName ) {
-							groupName = 'Category';
-						} else if( 'post_tag' === groupName ) {
-							groupName = 'Tag';
-						}
-						options += '<optgroup label="' + groupName + '">';
-						$.each(terms, function (i, term) {
-							var sel_option = "";
-							if (in_array(index + "_" + i, tax_selected)) {
-								sel_option = "selected";
-								if ( $("#feedzy_post_terms").hasClass('fz-chosen-custom-tag') ) {
-									var removeItem = index + "_" + i;
-									tax_selected = $.grep(tax_selected, function(value) {
-										return value != removeItem;
-									});
-								}
+				let options = '';
+				if (response.length !== 0) {
+					$.each(response, function (index, terms) {
+						if (terms) {
+							let groupName = index;
+							if ('category' === groupName) {
+								groupName = 'Category';
+							} else if ('post_tag' === groupName) {
+								groupName = 'Tag';
 							}
+							options += '<optgroup label="' + groupName + '">';
+							$.each(terms, function (i, term) {
+								let sel_option = '';
+								if (in_array(index + '_' + i, tax_selected)) {
+									sel_option = 'selected';
+									if (
+										$('#feedzy_post_terms').hasClass(
+											'fz-chosen-custom-tag'
+										)
+									) {
+										const removeItem = index + '_' + i;
+										tax_selected = $.grep(
+											tax_selected,
+											function (value) {
+												return value != removeItem;
+											}
+										);
+									}
+								}
+								options +=
+									'<option value="' +
+									index +
+									'_' +
+									i +
+									'" ' +
+									sel_option +
+									'>' +
+									term +
+									'</option>';
+							});
+							options += '</optgroup>';
+						}
+					});
+					tax_selected = tax_selected.filter(function (item) {
+						return '' !== item;
+					});
+					if (
+						tax_selected.length > 0 &&
+						$('#feedzy_post_terms').hasClass('fz-chosen-custom-tag')
+					) {
+						$.each(tax_selected, function (index, customTag) {
 							options +=
 								'<option value="' +
-								index +
-								"_" +
-								i +
-								'" ' +
-								sel_option +
-								">" +
-								term +
-								"</option>";
+								customTag +
+								'" selected>' +
+								customTag +
+								'</option>';
 						});
-						options += "</optgroup>";
 					}
-				});
-				tax_selected = tax_selected.filter( function(item) { return '' !== item; } );
-				if ( tax_selected.length > 0 && $("#feedzy_post_terms").hasClass('fz-chosen-custom-tag') ) {
-					$.each(tax_selected, function (index, customTag) {
-						options += '<option value="' + customTag + '" selected>' + customTag + '</option>';
-					} );
+				} else {
+					show_terms = false;
+					options = $('#empty_select_tpl').html();
 				}
-			} else {
-				show_terms = false;
-				options = $("#empty_select_tpl").html();
-			}
 
-			$("#feedzy_post_terms").html(options).trigger("chosen:updated");
-		}, 'json');
+				$('#feedzy_post_terms').html(options).trigger('chosen:updated');
+			},
+			'json'
+		);
 		return true;
 	}
 
 	function htmlEntities(str) {
-		return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+		return String(str)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#039;');
 	}
 
 	function escapeSelector(string) {
-		return String(string).replace(/([ !"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~])/g,'\\$1');
+		return String(string).replace(
+			/([ !"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~])/g,
+			'\\$1'
+		);
 	}
 
 	$(document).ready(function () {
@@ -250,283 +291,365 @@
 	});
 
 	function initImportScreen() {
-		$("button.btn-submit").on("click", function (e) {
-			$(window).unbind("beforeunload");
-			$("#custom_post_status").val($(this).val());
+		$('button.btn-submit').on('click', function (e) {
+			$(window).unbind('beforeunload');
+			$('#custom_post_status').val($(this).val());
 			e.preventDefault();
-			$("#post").submit();
+			$('#post').submit();
 			return false;
 		});
 
-		$( '#feedzy-import-source' ).on( 'blur', function(e) {
-			var addTagBtn = $( this ).parents( '.fz-input-icon' ).find( '.add-outside-tags' );
-			addTagBtn.trigger( 'click' );
-			$( this ).val('');
-		} );
+		$('#feedzy-import-source').on('blur', function (e) {
+			const addTagBtn = $(this)
+				.parents('.fz-input-icon')
+				.find('.add-outside-tags');
+			addTagBtn.trigger('click');
+			$(this).val('');
+		});
 
-		$( '.feedzy-keyword-filter, #feedzy-import-source' ).on('keyup keypress', function(e) {
-			var keyCode = e.keyCode || e.which;
-			var addTagBtn = $( this ).parents( '.fz-input-icon' ).find( '.add-outside-tags' );
+		$('.feedzy-keyword-filter, #feedzy-import-source').on(
+			'keyup keypress',
+			function (e) {
+				const keyCode = e.keyCode || e.which;
+				const addTagBtn = $(this)
+					.parents('.fz-input-icon')
+					.find('.add-outside-tags');
 
-			if ( '' === $( this ).val() ) {
-				addTagBtn.attr( 'disabled', true );
-			} else if ( addTagBtn.hasClass( 'fz-plus-btn' ) ) {
-				addTagBtn.removeAttr( 'disabled' );
+				if ('' === $(this).val()) {
+					addTagBtn.attr('disabled', true);
+				} else if (addTagBtn.hasClass('fz-plus-btn')) {
+					addTagBtn.removeAttr('disabled');
+				}
+
+				if (keyCode === 13) {
+					e.preventDefault();
+					addTagBtn.trigger('click');
+					$(this).val('');
+					return false;
+				}
 			}
+		);
 
-			if ( keyCode === 13 ) {
-				e.preventDefault();
-				addTagBtn.trigger( 'click' );
-				$( this ).val('');
-				return false;
-			}
-		} );
+		$('a.dropdown-item:not(.source,[data-action_popup])').on(
+			'click',
+			append_tag
+		);
+		$('.add-outside-tags').on('click', append_outside_tag);
+		$('a.dropdown-item.source').on('click', add_source);
+		$(document).on('click', '.btn-remove-fields', remove_row);
+		$('#new_custom_fields').on('click', new_row);
 
-		$("a.dropdown-item:not(.source,[data-action_popup])").on("click", append_tag);
-		$(".add-outside-tags").on("click", append_outside_tag);
-		$("a.dropdown-item.source").on("click", add_source);
-		$( document ).on( 'click', '.btn-remove-fields', remove_row );
-		$("#new_custom_fields").on("click", new_row);
-
-		$(".feedzy-toggle").on("click", update_status);
-		$(".dropdown-toggle").on("click", toggle_dropdown);
-		if ($("#toplevel_page_feedzy-admin-menu li").hasClass("current")) {
-			$("#toplevel_page_feedzy-admin-menu")
-				.removeClass("wp-not-current-submenu")
-				.addClass("wp-has-current-submenu");
+		$('.feedzy-toggle').on('click', update_status);
+		$('.dropdown-toggle').on('click', toggle_dropdown);
+		if ($('#toplevel_page_feedzy-admin-menu li').hasClass('current')) {
+			$('#toplevel_page_feedzy-admin-menu')
+				.removeClass('wp-not-current-submenu')
+				.addClass('wp-has-current-submenu');
 		}
-		$(".feedzy-chosen").chosen({ width: "100%" });
-		$("#feedzy_post_type").on("change", update_taxonomy);
-		$("#feedzy_post_status").trigger("change");
+		$('.feedzy-chosen').chosen({ width: '100%' });
+		$('#feedzy_post_type').on('change', update_taxonomy);
+		$('#feedzy_post_status').trigger('change');
 
 		// Add magic tag support for post taxonomy field.
-		$("#feedzy_post_terms.fz-chosen-custom-tag").on("chosen:no_results", function() {
-			var select = $(this);
-			var search = select.siblings(".chosen-container").find(".chosen-choices .search-field:last input");
-			var text = htmlEntities(search.val());
-    		// dont add if it already exists
-			if (! select.find('option[value=' + escapeSelector(search.val()) + ']').length) {
-				var btn = $('<li class="active-result highlighted">' + text + '</li>');
-				btn.on("mousedown mouseup click", function(e) {
-					var arr = select.val();
-					select.html(select.html() + "<option value='" + text + "'>" + text + "</option>");
-					select.val(arr.concat([text]));
-					select.trigger("chosen:updated").trigger('chosen:close');
-					// search.focus();
-					e.stopImmediatePropagation();
-					return false;
-				});
-				search.on("keydown", function(e) {
-					if (e.which == 13) {
-						btn.click();
+		$('#feedzy_post_terms.fz-chosen-custom-tag').on(
+			'chosen:no_results',
+			function () {
+				const select = $(this);
+				const search = select
+					.siblings('.chosen-container')
+					.find('.chosen-choices .search-field:last input');
+				const text = htmlEntities(search.val());
+				// dont add if it already exists
+				if (
+					!select.find(
+						'option[value=' + escapeSelector(search.val()) + ']'
+					).length
+				) {
+					const btn = $(
+						'<li class="active-result highlighted">' +
+							text +
+							'</li>'
+					);
+					btn.on('mousedown mouseup click', function (e) {
+						const arr = select.val();
+						select.html(
+							select.html() +
+								"<option value='" +
+								text +
+								"'>" +
+								text +
+								'</option>'
+						);
+						select.val(arr.concat([text]));
+						select
+							.trigger('chosen:updated')
+							.trigger('chosen:close');
+						// search.focus();
+						e.stopImmediatePropagation();
 						return false;
-					}
-				});
-				select.siblings(".chosen-container").find(".no-results").replaceWith(btn);
-			} else {
-				select.siblings(".chosen-container").find(".no-results").replaceWith('');
+					});
+					search.on('keydown', function (e) {
+						if (e.which == 13) {
+							btn.click();
+							return false;
+						}
+					});
+					select
+						.siblings('.chosen-container')
+						.find('.no-results')
+						.replaceWith(btn);
+				} else {
+					select
+						.siblings('.chosen-container')
+						.find('.no-results')
+						.replaceWith('');
+				}
 			}
-		})
+		);
 
 		// Add magic tag support for post taxonomy field.
-		$("#feedzy_post_author.fz-chosen-custom-tag").on("chosen:no_results", function() {
-			var select = $(this);
-			var search = select.siblings(".chosen-container").find(".chosen-search-input");
-			var text = htmlEntities(search.val().replace(/\s+/g, ''));
-			// dont add if it already exists
-			if (! select.find('option[value=' + escapeSelector(search.val().replace(/\s+/g, '')) + ']').length) {
-				var btn = $('<li class="active-result highlighted">' + text + '</li>');
-				btn.on("mousedown mouseup click", function(e) {
-					var arr = select.val() || [];
-					select.append("<option value='" + text + "' selected>" + text + "</option>");
-					select.trigger("chosen:updated").trigger('chosen:close');
-					e.stopImmediatePropagation();
-					return false;
-				});
-				search.on("keydown", function(e) {
-					if (e.which == 13) {
-						btn.click();
+		$('#feedzy_post_author.fz-chosen-custom-tag').on(
+			'chosen:no_results',
+			function () {
+				const select = $(this);
+				const search = select
+					.siblings('.chosen-container')
+					.find('.chosen-search-input');
+				const text = htmlEntities(search.val().replace(/\s+/g, ''));
+				// dont add if it already exists
+				if (
+					!select.find(
+						'option[value=' +
+							escapeSelector(search.val().replace(/\s+/g, '')) +
+							']'
+					).length
+				) {
+					const btn = $(
+						'<li class="active-result highlighted">' +
+							text +
+							'</li>'
+					);
+					btn.on('mousedown mouseup click', function (e) {
+						const arr = select.val() || [];
+						select.append(
+							"<option value='" +
+								text +
+								"' selected>" +
+								text +
+								'</option>'
+						);
+						select
+							.trigger('chosen:updated')
+							.trigger('chosen:close');
+						e.stopImmediatePropagation();
 						return false;
-					}
-				});
-				select.siblings(".chosen-container").find(".no-results").replaceWith(btn);
-				select.siblings(".chosen-container").find(".chosen-results").append('<li class="helper-text">' + feedzy.i10n.author_helper + '</li>');
-			} else {
-				select.siblings(".chosen-container").find(".no-results").replaceWith('');
+					});
+					search.on('keydown', function (e) {
+						if (e.which == 13) {
+							btn.click();
+							return false;
+						}
+					});
+					select
+						.siblings('.chosen-container')
+						.find('.no-results')
+						.replaceWith(btn);
+					select
+						.siblings('.chosen-container')
+						.find('.chosen-results')
+						.append(
+							'<li class="helper-text">' +
+								feedzy.i10n.author_helper +
+								'</li>'
+						);
+				} else {
+					select
+						.siblings('.chosen-container')
+						.find('.no-results')
+						.replaceWith('');
+				}
 			}
-		})
+		);
 
 		/*
          Form
          */
-		$(".f1 fieldset:first").fadeIn("slow");
+		$('.f1 fieldset:first').fadeIn('slow');
 
 		// next step
-		$(".f1 .btn-next").on("click", function () {
-			var parent_fieldset = $(this).parents("fieldset");
-			var next_step = true;
+		$('.f1 .btn-next').on('click', function () {
+			const parent_fieldset = $(this).parents('fieldset');
+			const next_step = true;
 			// navigation steps / progress steps
-			var current_active_step = $(this).parents(".f1").find(".f1-step.active");
-			var progress_line = $(this).parents(".f1").find(".f1-progress-line");
+			const current_active_step = $(this)
+				.parents('.f1')
+				.find('.f1-step.active');
+			const progress_line = $(this)
+				.parents('.f1')
+				.find('.f1-progress-line');
 
 			// fields validation
 			if (next_step) {
 				parent_fieldset.fadeOut(400, function () {
 					// change icons
 					current_active_step
-						.removeClass("active")
-						.addClass("activated")
+						.removeClass('active')
+						.addClass('activated')
 						.next()
-						.addClass("active");
+						.addClass('active');
 					// progress bar
-					bar_progress(progress_line, "right");
+					bar_progress(progress_line, 'right');
 					// show next step
 					$(this).next().fadeIn();
 					// scroll window to beginning of the form
-					scroll_to_class($(".f1"), 20);
+					scroll_to_class($('.f1'), 20);
 				});
 			}
 		});
 
 		// previous step
-		$(".f1 .btn-previous").on("click", function () {
+		$('.f1 .btn-previous').on('click', function () {
 			// navigation steps / progress steps
-			var current_active_step = $(this).parents(".f1").find(".f1-step.active");
-			var progress_line = $(this).parents(".f1").find(".f1-progress-line");
+			const current_active_step = $(this)
+				.parents('.f1')
+				.find('.f1-step.active');
+			const progress_line = $(this)
+				.parents('.f1')
+				.find('.f1-progress-line');
 
 			$(this)
-				.parents("fieldset")
+				.parents('fieldset')
 				.fadeOut(400, function () {
 					// change icons
 					current_active_step
-						.removeClass("active")
+						.removeClass('active')
 						.prev()
-						.removeClass("activated")
-						.addClass("active");
+						.removeClass('activated')
+						.addClass('active');
 					// progress bar
-					bar_progress(progress_line, "left");
+					bar_progress(progress_line, 'left');
 					// show previous step
 					$(this).prev().fadeIn();
 					// scroll window to beginning of the form
-					scroll_to_class($(".f1"), 20);
+					scroll_to_class($('.f1'), 20);
 				});
 		});
 
-		$("#feedzy-validate-feed").on("click", function (e) {
-			let $url = $("#feedzy-source-tags").val();
-			$url = $url.split( ',' );
-			$url = $.trim( $url.pop() );
-			let $anchor = $(this);
-			$anchor.attr("href", $anchor.attr("data-href-base") + $url);
+		$('#feedzy-validate-feed').on('click', function (e) {
+			let $url = $('#feedzy-source-tags').val();
+			$url = $url.split(',');
+			$url = $.trim($url.pop());
+			const $anchor = $(this);
+			$anchor.attr('href', $anchor.attr('data-href-base') + $url);
 		});
 
-		$("#preflight").on("click", function (e) {
+		$('#preflight').on('click', function (e) {
 			e.preventDefault();
-			var $fields = {};
+			const $fields = {};
 			// collect all elements.
-			$("#feedzy-import-form")
-				.find(":input")
+			$('#feedzy-import-form')
+				.find(':input')
 				.each(function (index, element) {
-					if ("undefined" === typeof $(element).attr("name")) {
+					if ('undefined' === typeof $(element).attr('name')) {
 						return;
 					}
-					$fields[$(element).attr("name")] = $(element).val();
+					$fields[$(element).attr('name')] = $(element).val();
 				});
-			tb_show(feedzy.i10n.dry_run_title, "TB_inline?");
-			$("#TB_ajaxContent").html(feedzy.i10n.dry_run_loading);
+			tb_show(feedzy.i10n.dry_run_title, 'TB_inline?');
+			$('#TB_ajaxContent').html(feedzy.i10n.dry_run_loading);
 			$.ajax({
 				url: ajaxurl,
-				method: "post",
+				method: 'post',
 				data: {
 					security: feedzy.ajax.security,
 					fields: $.param($fields),
-					action: "feedzy",
-					_action: "dry_run",
+					action: 'feedzy',
+					_action: 'dry_run',
 				},
-				success: function (data) {
-					$("#TB_ajaxContent").addClass("loaded");
-					$("#TB_ajaxContent div").html(data.data.output);
+				success(data) {
+					$('#TB_ajaxContent').addClass('loaded');
+					$('#TB_ajaxContent div').html(data.data.output);
 				},
 			});
 		});
 
 		// Click on pro/upgrade button.
-		$(document).on("click", ".only-pro-inner a", function (e) {
-			if ($(this).parents(".only-pro-content").css("opacity") == 0) {
+		$(document).on('click', '.only-pro-inner a', function (e) {
+			if ($(this).parents('.only-pro-content').css('opacity') == 0) {
 				e.preventDefault();
 			}
 		});
 
 		// Click to hide upsell notice.
-		$(document).on("click", ".remove-alert", function (e) {
-			var upSellNotice = $(this).parents( '.upgrade-alert' );
-			upSellNotice.fadeOut( 500,
-				function() {
-					upSellNotice.remove();
-					jQuery.post(
-						ajaxurl,
-						{
-							security: feedzy.ajax.security,
-							action: "feedzy",
-							_action: "remove_upsell_notice"
-						}
-					);
-				}
-			);
+		$(document).on('click', '.remove-alert', function (e) {
+			const upSellNotice = $(this).parents('.upgrade-alert');
+			upSellNotice.fadeOut(500, function () {
+				upSellNotice.remove();
+				jQuery.post(ajaxurl, {
+					security: feedzy.ajax.security,
+					action: 'feedzy',
+					_action: 'remove_upsell_notice',
+				});
+			});
 		});
 
 		// Save/Update Post Title.
-		$(document).on('input', "#post_title", function (e) {
-			jQuery( '.fz-form-wrap input[name="post_title"]' ).val( $(this).val() );
+		$(document).on('input', '#post_title', function (e) {
+			jQuery('.fz-form-wrap input[name="post_title"]').val($(this).val());
 		});
 
 		// Close dropdown when user click on document.
-		$( 'body' ).on( 'click', function( e ) {
-			if ( $( e.target ).parent( '.dropdown-item' ).length > 0 ) {
+		$('body').on('click', function (e) {
+			if ($(e.target).parent('.dropdown-item').length > 0) {
 				return;
 			}
-			if ( $( e.target ).attr( 'disabled' ) ) {
+			if ($(e.target).attr('disabled')) {
 				return;
 			}
-			if ( $( e.target ).hasClass( 'dashicons-arrow-down-alt2' ) ) {
+			if ($(e.target).hasClass('dashicons-arrow-down-alt2')) {
 				return;
 			}
-			if ( $( e.target ).hasClass( 'dashicons-plus-alt2' ) ) {
+			if ($(e.target).hasClass('dashicons-plus-alt2')) {
 				return;
 			}
-			if ( $( e.target ).hasClass( 'dropdown-toggle' ) ) {
+			if ($(e.target).hasClass('dropdown-toggle')) {
 				return;
 			}
-			$( '.dropdown.open' ).removeClass( 'open' );
-		} );
+			$('.dropdown.open').removeClass('open');
+		});
 
 		// Tagify for normal textbox.
-		$( '.fz-input-tagify:not(.fz-tagify-image):not([name="feedzy_meta_data[import_post_title]"])' ).tagify( {
+		$(
+			'.fz-input-tagify:not(.fz-tagify-image):not([name="feedzy_meta_data[import_post_title]"])'
+		).tagify({
 			editTags: false,
-			originalInputValueFormat: function( valuesArr ) {
-				return valuesArr.map( function( item ) {
-					return item.value;
-				} )
-				.join( ', ' );
-			}
-		} );
+			originalInputValueFormat(valuesArr) {
+				return valuesArr
+					.map(function (item) {
+						return item.value;
+					})
+					.join(', ');
+			},
+		});
 
 		// Tagify for normal mix content field.
-		$( '.fz-tagify-image' ).tagify( {
+		$('.fz-tagify-image').tagify({
 			mode: 'mix',
 			editTags: true,
 			userInput: true,
 			addTagOn: [],
 			templates: {
-				tag: function(tagData) {
-					try{
-						var decodeTagData = decodeURIComponent(tagData.value);
-						var isEncoded = typeof tagData.value === "string" && decodeTagData !== tagData.value;
-						var tagLabel = tagData.value;
-						if ( isEncoded ) {
-							decodeTagData = JSON.parse( decodeTagData );
+				tag(tagData) {
+					try {
+						let decodeTagData = decodeURIComponent(tagData.value);
+						const isEncoded =
+							typeof tagData.value === 'string' &&
+							decodeTagData !== tagData.value;
+						let tagLabel = tagData.value;
+						if (isEncoded) {
+							decodeTagData = JSON.parse(decodeTagData);
 							decodeTagData = decodeTagData[0] || {};
-							tagLabel = decodeTagData.tag.replaceAll( '_', ' ' );
+							tagLabel = decodeTagData.tag.replaceAll('_', ' ');
 							tagData['data-actions'] = tagData.value;
 							tagData['data-field_id'] = 'fz-image-action-tags';
 						}
@@ -535,31 +658,34 @@
 							<x title='remove tag' class='tagify__tag__removeBtn'></x>
 							<div>
 								<span class='tagify__tag-text'>${tagLabel}</span>
-								${tagData['data-actions'] ?
-									`<a href="javascript:;" class="tagify__filter-icon" ${this.getAttributes(tagData)}></a>` : ''
+								${
+									tagData['data-actions']
+										? `<a href="javascript:;" class="tagify__filter-icon" ${this.getAttributes(tagData)}></a>`
+										: ''
 								}
 							</div>
-						</tag>`
-					}
-					catch(err){}
-				}
-			}
-		} );
+						</tag>`;
+					} catch (err) {}
+				},
+			},
+		});
 
 		// Tagify for normal mix content field.
-		var mixContent = $( '.fz-textarea-tagify' ).tagify( {
+		const mixContent = $('.fz-textarea-tagify').tagify({
 			mode: 'mix',
 			editTags: false,
 			templates: {
-				tag: function( tagData ) {
-					try{
-						var decodeTagData = decodeURIComponent(tagData.value);
-						var isEncoded = typeof tagData.value === "string" && decodeTagData !== tagData.value;
-						var tagLabel = tagData.value;
-						if ( isEncoded ) {
-							decodeTagData = JSON.parse( decodeTagData );
+				tag(tagData) {
+					try {
+						let decodeTagData = decodeURIComponent(tagData.value);
+						const isEncoded =
+							typeof tagData.value === 'string' &&
+							decodeTagData !== tagData.value;
+						let tagLabel = tagData.value;
+						if (isEncoded) {
+							decodeTagData = JSON.parse(decodeTagData);
 							decodeTagData = decodeTagData[0] || {};
-							tagLabel = decodeTagData.tag.replaceAll( '_', ' ' );
+							tagLabel = decodeTagData.tag.replaceAll('_', ' ');
 							tagData['data-actions'] = tagData.value;
 							tagData['data-field_id'] = 'fz-content-action-tags';
 						}
@@ -568,30 +694,35 @@
 							<x title='remove tag' class='tagify__tag__removeBtn'></x>
 							<div>
 								<span class='tagify__tag-text'>${tagLabel}</span>
-								${tagData['data-actions'] ?
-									`<a href="javascript:;" class="tagify__filter-icon" ${this.getAttributes(tagData)}></a>` : ''
+								${
+									tagData['data-actions']
+										? `<a href="javascript:;" class="tagify__filter-icon" ${this.getAttributes(tagData)}></a>`
+										: ''
 								}
 							</div>
-						</tag>`
-					}
-					catch(err){}
-				}
-			}
-		} );
+						</tag>`;
+					} catch (err) {}
+				},
+			},
+		});
 
-		$( '.fz-input-tagify[name="feedzy_meta_data[import_post_title]"]:not(.fz-tagify-image)' ).tagify( {
+		$(
+			'.fz-input-tagify[name="feedzy_meta_data[import_post_title]"]:not(.fz-tagify-image)'
+		).tagify({
 			mode: 'mix',
 			editTags: false,
 			templates: {
-				tag: function( tagData ) {
-					try{
-						var decodeTagData = decodeURIComponent(tagData.value);
-						var isEncoded = typeof tagData.value === "string" && decodeTagData !== tagData.value;
-						var tagLabel = tagData.value;
-						if ( isEncoded ) {
-							decodeTagData = JSON.parse( decodeTagData );
+				tag(tagData) {
+					try {
+						let decodeTagData = decodeURIComponent(tagData.value);
+						const isEncoded =
+							typeof tagData.value === 'string' &&
+							decodeTagData !== tagData.value;
+						let tagLabel = tagData.value;
+						if (isEncoded) {
+							decodeTagData = JSON.parse(decodeTagData);
 							decodeTagData = decodeTagData[0] || {};
-							tagLabel = decodeTagData.tag.replaceAll( '_', ' ' );
+							tagLabel = decodeTagData.tag.replaceAll('_', ' ');
 							tagData['data-actions'] = tagData.value;
 							tagData['data-field_id'] = 'fz-title-action-tags';
 						}
@@ -600,92 +731,107 @@
 							<x title='remove tag' class='tagify__tag__removeBtn'></x>
 							<div>
 								<span class='tagify__tag-text'>${tagLabel}</span>
-								${tagData['data-actions'] ?
-									`<a href="javascript:;" class="tagify__filter-icon" ${this.getAttributes(tagData)}></a>` : ''
+								${
+									tagData['data-actions']
+										? `<a href="javascript:;" class="tagify__filter-icon" ${this.getAttributes(tagData)}></a>`
+										: ''
 								}
 							</div>
-						</tag>`
-					}
-					catch(err){
+						</tag>`;
+					} catch (err) {
 						console.error(err);
 					}
-				}
-			}
-		} );
+				},
+			},
+		});
 
 		// Tagify for outside tags with allowed duplicates.
-		$( '.fz-tagify-outside' ).tagify( {
-			editTags: true,
-			duplicates: true,
-			userInput: false,
-			originalInputValueFormat: function( valuesArr ) {
-				return valuesArr.map( function( item ) {
-					return item.value;
-				} )
-				.join( ', ' );
-			}
-		} )
-		.on( 'add', function( e ) {
-			var target = $( e.target );
-			target.parents( '.tag-list' ).removeClass( 'hidden' );
-		} )
-		.on( 'removeTag', function( e, tagData ) {
-			var target = $( e.target );
-			var emptyTags = target.parents( '.tag-list' ).find( '.tagify--empty' ).length;
-			if ( emptyTags ) {
-				target.parents( '.tag-list' ).addClass( 'hidden' );
-			}
-		} );
+		$('.fz-tagify-outside')
+			.tagify({
+				editTags: true,
+				duplicates: true,
+				userInput: false,
+				originalInputValueFormat(valuesArr) {
+					return valuesArr
+						.map(function (item) {
+							return item.value;
+						})
+						.join(', ');
+				},
+			})
+			.on('add', function (e) {
+				const target = $(e.target);
+				target.parents('.tag-list').removeClass('hidden');
+			})
+			.on('removeTag', function (e, tagData) {
+				const target = $(e.target);
+				const emptyTags = target
+					.parents('.tag-list')
+					.find('.tagify--empty').length;
+				if (emptyTags) {
+					target.parents('.tag-list').addClass('hidden');
+				}
+			});
 
 		// Tagify for outside tags with not allowed duplicates.
-		$( '.fz-tagify--outside' ).tagify( {
-			editTags: true,
-			userInput: false,
-			originalInputValueFormat: function( valuesArr ) {
-				return valuesArr.map( function( item ) {
-					return item.value;
-				} )
-				.join( ', ' );
-			}
-		} )
-		.on( 'add', function( e ) {
-			var target = $( e.target );
-			target.parents( '.tag-list' ).removeClass( 'hidden' );
-		} )
-		.on( 'removeTag', function( e, tagData ) {
-			var target = $( e.target );
-			var tagList = target.parents( '.tag-list' );
-			if ( tagList.find( '.tagify__tag' ).length === 0 ) {
-				tagList.addClass( 'hidden' );
-				tagList.find( 'input:text' ).val( '' );
-			}
-		} );
+		$('.fz-tagify--outside')
+			.tagify({
+				editTags: true,
+				userInput: false,
+				originalInputValueFormat(valuesArr) {
+					return valuesArr
+						.map(function (item) {
+							return item.value;
+						})
+						.join(', ');
+				},
+			})
+			.on('add', function (e) {
+				const target = $(e.target);
+				target.parents('.tag-list').removeClass('hidden');
+			})
+			.on('removeTag', function (e, tagData) {
+				const target = $(e.target);
+				const tagList = target.parents('.tag-list');
+				if (tagList.find('.tagify__tag').length === 0) {
+					tagList.addClass('hidden');
+					tagList.find('input:text').val('');
+				}
+			});
 
-		$( document ).on( 'change', 'input#remove-duplicates', function() {
-			if ( $(this).is(':checked') ) {
-				$('input#feedzy_mark_duplicate').attr( 'disabled', false );
+		$(document).on('change', 'input#remove-duplicates', function () {
+			if ($(this).is(':checked')) {
+				$('input#feedzy_mark_duplicate').attr('disabled', false);
 			} else {
-				$('input#feedzy_mark_duplicate').attr( 'disabled', true );
+				$('input#feedzy_mark_duplicate').attr('disabled', true);
 			}
-		} );
+		});
 
-		$(document).on( 'input', 'input[name="custom_vars_value[]"]', function () {
-			$(this)
-			.next('.fz-action-icon')
-			.toggleClass( 'disabled', $(this).val() === '' );
+		$(document).on(
+			'input',
+			'input[name="custom_vars_value[]"]',
+			function () {
+				$(this)
+					.next('.fz-action-icon')
+					.toggleClass('disabled', $(this).val() === '');
 
-			$(this)
-			.parent( '.fz-form-group' )
-			.find( 'input:hidden' )
-			.attr( 'disabled', $(this).val() === '' );
-		} );
+				$(this)
+					.parent('.fz-form-group')
+					.find('input:hidden')
+					.attr('disabled', $(this).val() === '');
+			}
+		);
 
-    // Append import button.
-		$( feedzy.i10n.importButton ).insertAfter( $( '.page-title-action', document ) );
-		$( $( '.page-title-action', document ) ).wrapAll( '<div class="fz-header-action"></div>' );
+		// Append import button.
+		$(feedzy.i10n.importButton).insertAfter(
+			$('.page-title-action', document)
+		);
+		$($('.page-title-action', document)).wrapAll(
+			'<div class="fz-header-action"></div>'
+		);
 
 		// Create dialog box
-		$( '#fz_import_export_upsell' ).dialog( {
+		$('#fz_import_export_upsell').dialog({
 			title: '',
 			dialogClass: 'wp-dialog',
 			autoOpen: false,
@@ -695,40 +841,49 @@
 			resizable: false,
 			closeOnEscape: true,
 			position: {
-				my: "center",
-				at: "center",
-				of: window
+				my: 'center',
+				at: 'center',
+				of: window,
 			},
-			open: function( event, ui ) {
-				$(".ui-dialog-titlebar-close", ui.dialog | ui).hide();
-				$(".ui-dialog-titlebar", ui.dialog | ui).hide();
+			open(event, ui) {
+				$('.ui-dialog-titlebar-close', ui.dialog | ui).hide();
+				$('.ui-dialog-titlebar', ui.dialog | ui).hide();
 			},
-			create: function() {
+			create() {
 				// style fix for WordPress admin
-				$( '.ui-dialog-titlebar-close' ).addClass( 'ui-button' );
+				$('.ui-dialog-titlebar-close').addClass('ui-button');
 			},
-		} );
+		});
 
-		$( '.fz-export-import-btn.only-pro, .fz-export-btn-pro' ).on( 'click', function( e ) {
-            e.preventDefault();
-            $( '#fz_import_export_upsell' ).dialog( 'open' );
-        });
+		$('.fz-export-import-btn.only-pro, .fz-export-btn-pro').on(
+			'click',
+			function (e) {
+				e.preventDefault();
+				$('#fz_import_export_upsell').dialog('open');
+			}
+		);
 
-        $( '#fz_import_export_upsell' ).on( 'click', '.close-modal', function ( e ) {
-        	e.preventDefault();
-            $( '#fz_import_export_upsell' ).dialog( 'close' );
-        } );
+		$('#fz_import_export_upsell').on('click', '.close-modal', function (e) {
+			e.preventDefault();
+			$('#fz_import_export_upsell').dialog('close');
+		});
 
-        $(document).on( 'click', '.fz-export-import-btn:not(.only-pro)', function( e ) {
-            e.preventDefault();
-            if ( $('.fz-import-field').length === 0 ) {
-	            var importField = $( '#fz_import_field_section' ).html();
-	            $( importField ).insertAfter( $( this ).parents( 'div.wrap' ).find( '.wp-header-end' ) );
-	        }
-            $('.fz-import-field').toggleClass('hidden');
-        });
+		$(document).on(
+			'click',
+			'.fz-export-import-btn:not(.only-pro)',
+			function (e) {
+				e.preventDefault();
+				if ($('.fz-import-field').length === 0) {
+					const importField = $('#fz_import_field_section').html();
+					$(importField).insertAfter(
+						$(this).parents('div.wrap').find('.wp-header-end')
+					);
+				}
+				$('.fz-import-field').toggleClass('hidden');
+			}
+		);
 
-		let url = new URL(window.location.href);
+		const url = new URL(window.location.href);
 		if (url.searchParams.has('imported')) {
 			url.searchParams.delete('imported');
 			history.replaceState(history.state, '', url.href);
@@ -736,44 +891,48 @@
 	}
 
 	function initSummary() {
-		$("tr.type-feedzy_imports").each(function (i, e) {
-			var $lastRunData = $(e).find("script.feedzy-last-run-data").html();
+		$('tr.type-feedzy_imports').each(function (i, e) {
+			const $lastRunData = $(e)
+				.find('script.feedzy-last-run-data')
+				.html();
 			$($lastRunData).insertAfter(e);
 		});
 
 		// pop-ups for informational text
-		$(".feedzy-dialog").dialog({
+		$('.feedzy-dialog').dialog({
 			modal: true,
 			autoOpen: false,
 			height: 400,
 			classes: {
-				"ui-dialog-content": "feedzy-dialog-content",
+				'ui-dialog-content': 'feedzy-dialog-content',
 			},
 			width: 500,
-			buttons:[
+			buttons: [
 				{
 					text: feedzy.i10n.okButton,
-					click: function () {
+					click() {
 						$(this).dialog('close');
-					}
-				}
-			]
+					},
+				},
+			],
 		});
 
 		// Error logs popup.
-		$(".feedzy-errors-dialog").dialog({
+		$('.feedzy-errors-dialog').dialog({
 			modal: true,
 			autoOpen: false,
 			height: 400,
 			width: 500,
-			buttons:[
+			buttons: [
 				{
 					text: feedzy.i10n.clearLogButton,
 					class: 'button button-primary feedzy-clear-logs',
-					click: function (event) {
-						var clearButton = $(event.target);
-						var dialogBox = $(this);
-						$('<span class="feedzy-spinner spinner is-active"></span>').insertAfter(clearButton);
+					click(event) {
+						const clearButton = $(event.target);
+						const dialogBox = $(this);
+						$(
+							'<span class="feedzy-spinner spinner is-active"></span>'
+						).insertAfter(clearButton);
 						clearButton.attr('disabled', true);
 						$.post(
 							ajaxurl,
@@ -784,104 +943,111 @@
 								_action: 'clear_error_logs',
 							},
 							function () {
-								clearButton
-								.next('.feedzy-spinner')
-								.remove();
+								clearButton.next('.feedzy-spinner').remove();
 
 								dialogBox
-								.find('.feedzy-error.feedzy-api-error')
-								.html('<div class="notice notice-success fz-notice"><p>' + feedzy.i10n.removeErrorLogsMsg + '</p></div>')
+									.find('.feedzy-error.feedzy-api-error')
+									.html(
+										'<div class="notice notice-success fz-notice"><p>' +
+											feedzy.i10n.removeErrorLogsMsg +
+											'</p></div>'
+									);
 							}
 						);
-					}
+					},
 				},
 				{
 					text: feedzy.i10n.okButton,
 					class: 'alignright',
-					click: function () {
+					click() {
 						$(this).dialog('close');
-					}
-				}
-			]
+					},
+				},
+			],
 		});
 
-		$(".feedzy-dialog-open").on("click", function (e) {
+		$('.feedzy-dialog-open').on('click', function (e) {
 			e.preventDefault();
-			var dialog = $(this).attr("data-dialog");
-			$("." + dialog).dialog("open");
+			const dialog = $(this).attr('data-dialog');
+			$('.' + dialog).dialog('open');
 		});
 
 		// run now.
-		$(".feedzy-run-now").on("click", function (e) {
+		$('.feedzy-run-now').on('click', function (e) {
 			e.preventDefault();
-			var button = $(this);
+			const button = $(this);
 			button.val(feedzy.i10n.importing);
 
-			var numberRow = button
-				.parents("tr")
-				.find("~ tr.feedzy-import-status-row:first")
-				.find("td tr:first");
-			numberRow.find("td").hide();
+			const numberRow = button
+				.parents('tr')
+				.find('~ tr.feedzy-import-status-row:first')
+				.find('td tr:first');
+			numberRow.find('td').hide();
 			numberRow
-				.find("td:first")
-				.addClass("feedzy_run_now_msg")
-				.attr("colspan", 5)
+				.find('td:first')
+				.addClass('feedzy_run_now_msg')
+				.attr('colspan', 5)
 				.html(feedzy.i10n.importing)
 				.show();
 
 			$.ajax({
 				url: ajaxurl,
-				method: "post",
+				method: 'post',
 				data: {
 					security: feedzy.ajax.security,
-					id: $(this).attr("data-id"),
-					action: "feedzy",
-					_action: "run_now",
+					id: $(this).attr('data-id'),
+					action: 'feedzy',
+					_action: 'run_now',
 				},
-				success: function (data) {
-					if ( data.data.import_success ) {
-						numberRow.find("td:first").addClass('import_success');
+				success(data) {
+					if (data.data.import_success) {
+						numberRow.find('td:first').addClass('import_success');
 					}
-					numberRow.find("td:first").html(data.data.msg);
+					numberRow.find('td:first').html(data.data.msg);
 				},
-				complete: function () {
+				complete() {
 					button.val(feedzy.i10n.run_now);
 				},
 			});
 		});
 
 		// toggle the errors div to expand/collapse
-		$("td.column-feedzy-last_run .feedzy-api-error").on("click", function () {
-			if ($(this).hasClass("expand")) {
-				$(this).removeClass("expand");
-			} else {
-				$(this).addClass("expand");
+		$('td.column-feedzy-last_run .feedzy-api-error').on(
+			'click',
+			function () {
+				if ($(this).hasClass('expand')) {
+					$(this).removeClass('expand');
+				} else {
+					$(this).addClass('expand');
+				}
 			}
-		});
+		);
 
 		// purge data ajax call
-		$(".feedzy_purge").on("click", function (e) {
+		$('.feedzy_purge').on('click', function (e) {
 			e.preventDefault();
-			var element = $(this);
-			var deleteImportedPosts = confirm(feedzy.i10n.delete_post_message);
+			const element = $(this);
+			const deleteImportedPosts = confirm(
+				feedzy.i10n.delete_post_message
+			);
 			if (!deleteImportedPosts) {
 				return;
 			}
 			showSpinner(element);
 			$.ajax({
 				url: ajaxurl,
-				method: "post",
+				method: 'post',
 				data: {
 					security: feedzy.ajax.security,
-					id: $(this).find("a").attr("data-id"),
-					action: "feedzy",
-					_action: "purge",
-					del_imported_posts: deleteImportedPosts
+					id: $(this).find('a').attr('data-id'),
+					action: 'feedzy',
+					_action: 'purge',
+					del_imported_posts: deleteImportedPosts,
 				},
-				success: function () {
+				success() {
 					location.reload();
 				},
-				complete: function () {
+				complete() {
 					hideSpinner(element);
 				},
 			});
@@ -892,14 +1058,14 @@
 		$('input[name="custom_vars_key[]"]')
 			.autocomplete({
 				minLength: 0,
-				source: function (request, response) {
+				source(request, response) {
 					jQuery.post(
 						ajaxurl,
 						{
 							security: feedzy.ajax.security,
-							action: "feedzy",
-							_action: "fetch_custom_fields",
-							post_type: $("#feedzy_post_type").val(),
+							action: 'feedzy',
+							_action: 'fetch_custom_fields',
+							post_type: $('#feedzy_post_type').val(),
 							search_key: request.term,
 						},
 						function (res) {
@@ -909,71 +1075,73 @@
 								response([
 									{
 										label: res.data.not_found_msg,
-										value: "not_found_msg",
+										value: 'not_found_msg',
 									},
 								]);
 							}
 						}
 					);
 				},
-				select: function (event, ui) {
-					if ("not_found_msg" === ui.item.value) {
+				select(event, ui) {
+					if ('not_found_msg' === ui.item.value) {
 						setTimeout(function () {
-							$(event.target).val("");
+							$(event.target).val('');
 						});
 					}
 				},
-				focus: function () {
-					if ($(this).autocomplete("widget").is(":visible")) {
+				focus() {
+					if ($(this).autocomplete('widget').is(':visible')) {
 						return;
 					}
-					$(this).autocomplete("search", $(this).val());
+					$(this).autocomplete('search', $(this).val());
 				},
 			})
-			.on("click", function () {
+			.on('click', function () {
 				$(this).keydown();
 			});
 	}
 
 	function showSpinner(el) {
-		el.parent().find(".feedzy-spinner").addClass("is-active");
+		el.parent().find('.feedzy-spinner').addClass('is-active');
 	}
 	function hideSpinner(el) {
-		el.parent().find(".feedzy-spinner").removeClass("is-active");
+		el.parent().find('.feedzy-spinner').removeClass('is-active');
 	}
 
 	function feedzyAccordion() {
 		$(
-			".feedzy-accordion .feedzy-accordion-item .feedzy-accordion-item__button"
-		).on("click", function () {
-			var current_item = $(this).parents();
+			'.feedzy-accordion .feedzy-accordion-item .feedzy-accordion-item__button'
+		).on('click', function () {
+			const current_item = $(this).parents();
 			$(
-				".feedzy-accordion .feedzy-accordion-item .feedzy-accordion-item__content"
+				'.feedzy-accordion .feedzy-accordion-item .feedzy-accordion-item__content'
 			).each(function (i, el) {
 				if ($(el).parent().is(current_item)) {
-					$(el).prev().toggleClass("is-active");
+					$(el).prev().toggleClass('is-active');
 					$(el).slideToggle();
-					$(this).toggleClass("is-active");
+					$(this).toggleClass('is-active');
 				} else {
-					$(el).prev().removeClass("is-active");
+					$(el).prev().removeClass('is-active');
 					$(el).slideUp();
-					$(this).removeClass("is-active");
+					$(this).removeClass('is-active');
 				}
 			});
-			if ( $('#fz-import-map-content').hasClass('is-active') ) {
+			if ($('#fz-import-map-content').hasClass('is-active')) {
 				$('#feedzy_post_type').trigger('change');
 			}
 		});
-		$(".feedzy-accordion .feedzy-accordion-item .feedzy-accordion-item__button")
+		$(
+			'.feedzy-accordion .feedzy-accordion-item .feedzy-accordion-item__button'
+		)
 			.first()
 			.parent()
-			.addClass("is-active");
+			.addClass('is-active');
 		$(
-			".feedzy-accordion .feedzy-accordion-item > .feedzy-accordion-item__content"
+			'.feedzy-accordion .feedzy-accordion-item > .feedzy-accordion-item__content'
 		)
 			.first()
 			.show()
-			.addClass("is-active");
+			.addClass('is-active');
 	}
 
 	function feedzyTab() {
@@ -998,73 +1166,104 @@
 
 	function feedzyMediaUploader() {
 		// on upload button click
-		$( 'body' ).on( 'click', '.feedzy-open-media', function( e ) {
+		$('body').on('click', '.feedzy-open-media', function (e) {
 			e.preventDefault();
-			var button = $( this ),
-			wp_media_uploader = wp.media( {
+			const button = $(this);
+			const wpMediaUploader = wp.media({
 				title: feedzy.i10n.media_iframe_title,
-				library : {
-					type : 'image'
+				library: {
+					type: 'image',
 				},
 				button: {
-					text: feedzy.i10n.media_iframe_button
+					text: feedzy.i10n.media_iframe_button,
 				},
-				multiple: true
-			} ).on( 'select', function() { // it also has "open" and "close" events
-				var selectedAttachments = wp_media_uploader.state().get( 'selection' );
-				var countSelected = selectedAttachments?.toJSON()?.length;
-				button.parents( '.fz-form-group' ).find( '.feedzy-media-preview' ).remove();
+				multiple: true,
+			});
+
+			wpMediaUploader.on('select', function () {
+				// it also has "open" and "close" events
+				const selectedAttachments = wpMediaUploader
+					.state()
+					.get('selection');
+				const countSelected = selectedAttachments?.toJSON()?.length;
+				button
+					.parents('.fz-form-group')
+					.find('.feedzy-media-preview')
+					.remove();
 				// Display image preview when a single image is selected.
-				if ( 1 === countSelected ) {
-					var attachment = selectedAttachments.first().toJSON();
-					var attachmentUrl = attachment.url;
-					if ( attachment.sizes.thumbnail ) {
+				if (1 === countSelected) {
+					const attachment = selectedAttachments.first().toJSON();
+					let attachmentUrl = attachment.url;
+					if (attachment.sizes?.thumbnail) {
 						attachmentUrl = attachment.sizes.thumbnail.url;
 					}
-					if ( $( '.feedzy-media-preview' ).length ) {
-						$( '.feedzy-media-preview' ).find( 'img' ).attr( 'src', attachmentUrl );
+					if ($('.feedzy-media-preview').length) {
+						$('.feedzy-media-preview')
+							.find('img')
+							.attr('src', attachmentUrl);
 					} else {
-						$( '<div class="fz-form-group mb-20 feedzy-media-preview"><img src="' + attachmentUrl + '"></div>' ).insertBefore( button.parent() );
+						$(
+							'<div class="fz-form-group mb-20 feedzy-media-preview"><img src="' +
+								attachmentUrl +
+								'"></div>'
+						).insertBefore(button.parent());
 					}
 				} else {
-					$( '<div class="fz-form-group mb-20 feedzy-media-preview"><a href="javascript:;" class="btn btn-outline-primary feedzy-images-selected">' + feedzy.i10n.action_btn_text_3.replace( '%d', countSelected ) + '</a></div>' ).insertBefore( button.parent() );
+					$(
+						'<div class="fz-form-group mb-20 feedzy-media-preview fz-fallback-images">' +
+							selectedAttachments
+								?.toJSON()
+								?.map(({ url, sizes }) => {
+									if ( sizes?.thumbnail ) {
+										url = sizes.thumbnail.url;
+									}
+									return `<img width="150" height="150" src="${url}" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy">`;
+								})
+								.join('') +
+							'</div>'
+					).insertBefore(button.parent());
 				}
 				// Get all selected attachment ids.
-				var ids = selectedAttachments.map( function( attachment ) {
-					return attachment.id;
-				} ).join( ',' );
+				const ids = selectedAttachments
+					.map(function (attachment) {
+						return attachment.id;
+					})
+					.join(',');
 
-				button.parent().find( '.feedzy-remove-media' ).addClass( 'is-show' );
-				button.parent().find( 'input:hidden' ).val( ids ).trigger( 'change' );
-				$( '.feedzy-open-media' ).html( feedzy.i10n.action_btn_text_2 );
-			} );
+				button
+					.parent()
+					.find('.feedzy-remove-media')
+					.addClass('is-show');
+				button.parent().find('input:hidden').val(ids).trigger('change');
+				$('.feedzy-open-media').html(feedzy.i10n.action_btn_text_2);
+			});
 
-			wp_media_uploader.on(' open', function() {
-				var selectedVal = button.parent().find( 'input:hidden' ).val();
-				if ( '' === selectedVal ) {
+			wpMediaUploader.on(' open', function () {
+				const selectedVal = button.parent().find('input:hidden').val();
+				if ('' === selectedVal) {
 					return;
 				}
-				var selection = wp_media_uploader.state().get('selection');
+				const selection = wpMediaUploader.state().get('selection');
 
-				selectedVal.split(',').forEach(function( id ) {
-					var attachment = wp.media.attachment( id );
+				selectedVal.split(',').forEach(function (id) {
+					const attachment = wp.media.attachment(id);
 					attachment.fetch();
 					selection.add(attachment ? [attachment] : []);
 				});
-			} );
+			});
 
-			wp_media_uploader.open();
+			wpMediaUploader.open();
 		});
 
-		$(document).on( 'click', '.feedzy-images-selected', function( e ) {
+		$(document).on('click', '.feedzy-images-selected', function (e) {
 			$(this)
-			.parents( '.fz-form-group' )
-			.find( '.feedzy-open-media' )
-			.trigger( 'click' );
+				.parents('.fz-form-group')
+				.find('.feedzy-open-media')
+				.trigger('click');
 			e.preventDefault();
-		} );
+		});
 	}
-}(jQuery, feedzy));
+})(jQuery, feedzy);
 
 /**
  * Initialize the remove fallback image button from General Feed Settings tab.
@@ -1076,10 +1275,13 @@ function initRemoveFallbackImageBtn() {
 
 		// Reset the image preview.
 		document.querySelector('.feedzy-media-preview').remove();
-		removeFallbackImage.classList.remove('is-show');
+		// removeFallbackImage.classList.remove('is-show');
 
 		// Reset the input.
-		document.querySelector('input[name="feedzy_meta_data[default_thumbnail_id]"]').value = '0';
-		document.querySelector('.feedzy-open-media').innerHTML = feedzy.i10n.action_btn_text_1;
+		document.querySelector(
+			'input[name="feedzy_meta_data[default_thumbnail_id]"]'
+		).value = '0';
+		document.querySelector('.feedzy-open-media').innerHTML =
+			feedzy.i10n.action_btn_text_1;
 	});
 }

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -1290,13 +1290,25 @@
 			'change',
 			function () {
 				const selectedValue = $(this).val();
+				const thumbnailValue = $('input[name="feedzy_meta_data[default_thumbnail_id]"]').val();
+				const hasImagePreview = $('#custom-fallback-section .feedzy-media-preview').length > 0;
+				const hasThumbnails = (thumbnailValue && thumbnailValue !== '' && thumbnailValue !== '0') || hasImagePreview;
 
 				if (selectedValue === 'custom') {
 					$('#custom-fallback-section').show();
 					$('#general-fallback-preview').hide();
-				} else {
+					
+					if (hasThumbnails) {
+						$('.feedzy-open-media').html(feedzy.i10n.action_btn_text_2);
+						$('.feedzy-remove-media').addClass('is-show');
+					} else {
+						$('.feedzy-open-media').html(feedzy.i10n.action_btn_text_1);
+						$('.feedzy-remove-media').removeClass('is-show');
+					}
+				} else if (selectedValue === 'general') {
 					$('#custom-fallback-section').hide();
 					$('#general-fallback-preview').show();
+					$('input[name="feedzy_meta_data[default_thumbnail_id]"]').val('');
 				}
 			}
 		);

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -288,6 +288,7 @@
 		feedzyTab();
 		feedzyMediaUploader();
 		initRemoveFallbackImageBtn();
+		initFallbackImageOptions();
 	});
 
 	function initImportScreen() {
@@ -1214,7 +1215,7 @@
 							selectedAttachments
 								?.toJSON()
 								?.map(({ url, sizes }) => {
-									if ( sizes?.thumbnail ) {
+									if (sizes?.thumbnail) {
 										url = sizes.thumbnail.url;
 									}
 									return `<img width="150" height="150" src="${url}" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy">`;
@@ -1263,6 +1264,47 @@
 			e.preventDefault();
 		});
 	}
+
+	function initFallbackImageOptions() {
+		$('#use-inherited-thumbnail').on('change', function () {
+			if ($(this).is(':checked')) {
+				$('#custom-fallback-image-section').hide();
+				$('#inherited-fallback-image-section').show();
+				$('#feed-post-default-thumbnail').val('');
+			} else {
+				$('#custom-fallback-image-section').show();
+				$('#inherited-fallback-image-section').hide();
+			}
+		});
+
+		$('.feedzy-remove-media').on('click', function () {
+			if (
+				$('#use-inherited-thumbnail').length && 
+				$('#use-inherited-thumbnail').is(':checked')
+			) {
+				return false;
+			}
+		});
+
+		$('input[name="feedzy_meta_data[fallback_image_option]"]').on(
+			'change',
+			function () {
+				const selectedValue = $(this).val();
+
+				if (selectedValue === 'custom') {
+					$('#custom-fallback-section').show();
+					$('#general-fallback-preview').hide();
+				} else {
+					$('#custom-fallback-section').hide();
+					$('#general-fallback-preview').show();
+				}
+			}
+		);
+
+		$(
+			'input[name="feedzy_meta_data[fallback_image_option]"]:checked'
+		).trigger('change');
+	}
 })(jQuery, feedzy);
 
 /**
@@ -1275,7 +1317,7 @@ function initRemoveFallbackImageBtn() {
 
 		// Reset the image preview.
 		document.querySelector('.feedzy-media-preview').remove();
-		// removeFallbackImage.classList.remove('is-show');
+		removeFallbackImage.classList.remove('is-show');
 
 		// Reset the input.
 		document.querySelector(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Now the user can select between general settings and their custom fallback image.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="2660" height="990" alt="CleanShot 2025-08-04 at 13 14 44@2x" src="https://github.com/user-attachments/assets/e27666f6-144a-4c29-9116-6c42b951defc" />
<img width="2686" height="1436" alt="CleanShot 2025-08-04 at 13 14 54@2x" src="https://github.com/user-attachments/assets/ba64c142-99bf-4a30-b9b8-8346efed4fc0" />



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Try to interact with the general feed settings in the import page.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/885#event-18809301811
<!-- Should look like this: `Closes #1, #2, #3.` . -->
