### PR TITLE
fix: update help text to include Feedzy Blocks in image usage descrip…

### DIFF
--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -110,8 +110,8 @@
 								<?php do_action( 'feedzy_general_setting_before' ); ?>	
 								<div class="form-block">
 									<div class="fz-form-group">
-										<label for="feed-post-default-thumbnail" class="form-label"><?php echo esc_html_e( 'Fallback image for imported posts', 'feedzy-rss-feeds' ); ?></label>
-										<div class="help-text pb-8"><?php esc_html_e( 'Select an image to be the fallback featured image(Feed2Post).', 'feedzy-rss-feeds' ); ?></div>
+										<label for="feed-post-default-thumbnail" class="form-label"><?php echo esc_html_e( 'Fallback Featured Image Settings', 'feedzy-rss-feeds' ); ?></label>
+										<div class="help-text pb-8"><?php esc_html_e( 'Choose a default image to display when RSS feeds don\'t include images.', 'feedzy-rss-feeds' ); ?></div>
 										<?php
 										$btn_label = esc_html__( 'Choose image', 'feedzy-rss-feeds' );
 										if ( $default_thumbnail_id ) :
@@ -129,13 +129,13 @@
 										<div class="help-text">
 											<?php
 											echo wp_kses(
-												__( 'This image will be used for the <strong>imported posts</strong> and Feedzy Blocks if an image is not available in the source XML Feed.', 'feedzy-rss-feeds' ),
+												__( '<strong>How it works:</strong> When importing posts from RSS feeds, some items may not include images. This fallback image ensures all your <strong>imported posts</strong> have visual content by automatically applying this image as the featured image when needed.', 'feedzy-rss-feeds' ),
 												array(
 													'strong' => true,
 												)
 											);
 											?>
-											</div>
+										</div>
 									</div>
 								</div>
 								<div class="form-block">

--- a/includes/layouts/settings.php
+++ b/includes/layouts/settings.php
@@ -129,7 +129,7 @@
 										<div class="help-text">
 											<?php
 											echo wp_kses(
-												__( 'This image will be used for the <strong>imported posts</strong> if an image is not available in the source XML Feed.', 'feedzy-rss-feeds' ),
+												__( 'This image will be used for the <strong>imported posts</strong> and Feedzy Blocks if an image is not available in the source XML Feed.', 'feedzy-rss-feeds' ),
 												array(
 													'strong' => true,
 												)


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Changed the text. This makes it clearer that the fallback image serves more purposes.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
#### Current Version
<img width="2410" height="1088" alt="CleanShot 2025-08-08 at 10 59 48@2x" src="https://github.com/user-attachments/assets/6a117d99-937e-4d39-bdeb-a50ccd736b3b" />

#### Keeping Pattern
<img width="2344" height="860" alt="CleanShot 2025-08-08 at 11 00 49@2x" src="https://github.com/user-attachments/assets/3bd3230f-6ec1-4787-8a25-308e2b12e336" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/866
<!-- Should look like this: `Closes #1, #2, #3.` . -->
