### PR TITLE
Fixed close actions popup on outside click

### DIFF
--- a/js/ActionPopup/index.js
+++ b/js/ActionPopup/index.js
@@ -333,7 +333,7 @@ const ActionModal = () => {
 	return (
 		<Fragment>
 		{ isOpen && (
-			<Modal isDismissible={ false } className="fz-action-popup" overlayClassName="fz-popup-wrap">
+			<Modal isDismissible={ false } onRequestClose={ closeModal } className="fz-action-popup" overlayClassName="fz-popup-wrap">
 				<div className="fz-action-content">
 					<div className="fz-action-header">
 						<div className="fz-modal-title">


### PR DESCRIPTION
### Summary
Close the action pop-up by clicking outside or pressing the Esc key.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/858