### PR TITLE
fix: remove deprecated 'Feedzy Demo' section from documentation layout

### DIFF
--- a/includes/layouts/feedzy-documentation.php
+++ b/includes/layouts/feedzy-documentation.php
@@ -81,20 +81,6 @@ Layout For Document Page of Feedzy RSS Feeds
 		<li>
 			<div class="fz-document-box">
 				<div class="fz-document-box-img">
-					<img src="<?php echo esc_url( FEEDZY_ABSURL . 'img/feedzy-demo.jpg' ); ?>" alt="">
-				</div>
-				<div class="fz-document-box-content">
-					<h3 class="h3"><?php esc_html_e( 'Feedzy Demo', 'feedzy-rss-feeds' ); ?></h3>
-					<p><?php esc_html_e( 'See how Feedzy can integrate with your website by browsing our examples.', 'feedzy-rss-feeds' ); ?></p>
-					<div class="cta">
-						<a href="https://demo.themeisle.com/feedzy-rss-feeds/" class="btn btn-outline-primary" target="_blank"><?php esc_html_e( 'Learn more', 'feedzy-rss-feeds' ); ?></a>
-					</div>
-				</div>
-			</div>
-		</li>
-		<li>
-			<div class="fz-document-box">
-				<div class="fz-document-box-img">
 					<img src="<?php echo esc_url( FEEDZY_ABSURL . 'img/in-feedzy.jpg' ); ?>" alt="">
 				</div>
 				<div class="fz-document-box-content">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Remove Feedzy Demo from the Documentation tab.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="4378" height="2466" alt="CleanShot 2025-08-13 at 18 19 00@2x" src="https://github.com/user-attachments/assets/936b9293-3754-446c-be09-4e2048e32025" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the layout

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/881
<!-- Should look like this: `Closes #1, #2, #3.` . -->
