### PR TITLE
feat: add fallback image per import on Loop

### DIFF
--- a/includes/gutenberg/feedzy-rss-feeds-loop-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-loop-block.php
@@ -139,8 +139,8 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			'target'        => '_blank',
 			'keywords_ban'  => '',
 			'columns'       => '1',
-			'thumb'         => $thumb,
-			'default'       => $default_thumbnail_img,
+			'thumb'         => 'no',
+			'default'       => '',
 			'title'         => '',
 			'meta'          => 'yes',
 			'multiple_meta' => 'no',
@@ -297,7 +297,7 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			return $item['item_img_path'];
 		} 
 		
-		if ( 'yes' !== $thumb ) {
+		if ( 'auto' === $thumb ) {
 			return '';
 		}
 
@@ -311,7 +311,12 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			isset( $settings, $settings['general'], $settings['general']['default-thumbnail-id'] ) &&
 			! empty( $settings['general']['default-thumbnail-id'] )
 		) {
-			return wp_get_attachment_image_src( $settings['general']['default-thumbnail-id'], 'full' );
+			$media_img = wp_get_attachment_image_src( $settings['general']['default-thumbnail-id'], 'full' );
+			if (
+				is_array( $media_img ) && ! empty( $media_img[0] )
+			) {
+				return $media_img[0];
+			}
 		}
 		
 		return FEEDZY_ABSURL . 'img/feedzy.svg';

--- a/includes/gutenberg/feedzy-rss-feeds-loop-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-loop-block.php
@@ -130,6 +130,11 @@ class Feedzy_Rss_Feeds_Loop_Block {
 
 		$query   = isset( $attributes['query'] ) ? wp_parse_args( $attributes['query'], $default_query ) : $default_query;
 		$filters = isset( $attributes['conditions'] ) ? $attributes['conditions'] : array();
+		$thumb   = 'auto';
+	
+		if ( isset( $attributes['thumb'] ) && ! empty( $attributes['thumb'] ) ) {
+			$thumb = $attributes['thumb'];
+		}
 
 		$options = array(
 			'feeds'         => implode( ',', $feed_urls ),
@@ -139,7 +144,7 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			'target'        => '_blank',
 			'keywords_ban'  => '',
 			'columns'       => '1',
-			'thumb'         => 'no',
+			'thumb'         => $thumb,
 			'default'       => '',
 			'title'         => '',
 			'meta'          => 'yes',

--- a/includes/gutenberg/feedzy-rss-feeds-loop-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-loop-block.php
@@ -259,35 +259,7 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			case 'categories':
 				return isset( $item['item_categories'] ) ? $item['item_categories'] : '';
 			case 'image':
-				$settings              = apply_filters( 'feedzy_get_settings', array() );
-				$thumb                 = 'auto';
-				$default_thumbnail_img = '';
-
-				if ( isset( $attributes['thumb'] ) && ! empty( $attributes['thumb'] ) ) {
-					$thumb = $attributes['thumb'];
-				}
-
-				if ( 'no' === $thumb ) {
-					return '';
-				}
-
-				if ( isset( $item['item_img_path'] ) && ! empty( $item['item_img_path'] ) ) {
-					$default_thumbnail_img = $item['item_img_path'];
-				} elseif ( 'yes' === $thumb ) {
-					if (
-						isset( $attributes['fallbackImage'], $attributes['fallbackImage']['url'] ) &&
-						! empty( $attributes['fallbackImage']['url'] )
-					) {
-						$default_thumbnail_img = $attributes['fallbackImage']['url'];
-					} elseif ( $settings && ! empty( $settings['general']['default-thumbnail-id'] ) ) {
-						$default_thumbnail_img = wp_get_attachment_image_src( $settings['general']['default-thumbnail-id'], 'full' );
-						$default_thumbnail_img = ! empty( $default_thumbnail_img ) ? reset( $default_thumbnail_img ) : '';
-					} else {
-						$default_thumbnail_img = FEEDZY_ABSURL . 'img/feedzy.svg';
-					}
-				}
-
-				return $default_thumbnail_img;
+				return $this->get_thumbnail( $item, $attributes );
 			case 'media':
 				return isset( $item['item_media']['src'] ) ? $item['item_media']['src'] : '';
 			case 'price':
@@ -297,5 +269,51 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			default:
 				return '';
 		}
+	}
+
+	/**
+	 * Get Thumbnail of feed item.
+	 * 
+	 * Fallback to default thumbnail if not set. The Fallback image can be set in the block attributes or in the plugin settings.
+	 *
+	 * @param array<string, mixed> $item The feed item.
+	 * @param array<string, mixed> $attributes The block attributes.
+	 *
+	 * @return string The thumbnail URL.
+	 */
+	private function get_thumbnail( $item, $attributes ) {
+		$settings = apply_filters( 'feedzy_get_settings', array() );
+		$thumb    = 'yes';
+	
+		if ( isset( $attributes['thumb'] ) && ! empty( $attributes['thumb'] ) ) {
+			$thumb = $attributes['thumb'];
+		}
+	
+		if ( 'no' === $thumb ) {
+			return '';
+		}
+	
+		if ( isset( $item['item_img_path'] ) && ! empty( $item['item_img_path'] ) ) {
+			return $item['item_img_path'];
+		} 
+		
+		if ( 'yes' !== $thumb ) {
+			return '';
+		}
+
+		// Try to find the fallback image.
+		if (
+			isset( $attributes['fallbackImage'], $attributes['fallbackImage']['url'] ) &&
+			! empty( $attributes['fallbackImage']['url'] )
+		) {
+			return $attributes['fallbackImage']['url'];
+		} elseif (
+			isset( $settings, $settings['general'], $settings['general']['default-thumbnail-id'] ) &&
+			! empty( $settings['general']['default-thumbnail-id'] )
+		) {
+			return wp_get_attachment_image_src( $settings['general']['default-thumbnail-id'], 'full' );
+		}
+		
+		return FEEDZY_ABSURL . 'img/feedzy.svg';
 	}
 }

--- a/includes/gutenberg/feedzy-rss-feeds-loop-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-loop-block.php
@@ -128,12 +128,21 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			'refresh' => '12_hours',
 		);
 
-		$query   = isset( $attributes['query'] ) ? wp_parse_args( $attributes['query'], $default_query ) : $default_query;
-		$filters = isset( $attributes['conditions'] ) ? $attributes['conditions'] : array();
-		$thumb   = 'auto';
+		$query             = isset( $attributes['query'] ) ? wp_parse_args( $attributes['query'], $default_query ) : $default_query;
+		$filters           = isset( $attributes['conditions'] ) ? $attributes['conditions'] : array();
+		$thumb             = 'auto';
+		$default_thumbnail = '';
 	
 		if ( isset( $attributes['thumb'] ) && ! empty( $attributes['thumb'] ) ) {
 			$thumb = $attributes['thumb'];
+
+			if (
+				'yes' === $thumb &&
+				isset( $attributes['fallbackImage'], $attributes['fallbackImage']['url'] ) &&
+				! empty( $attributes['fallbackImage']['url'] )
+			) {
+				$default_thumbnail = $attributes['fallbackImage']['url'];
+			}
 		}
 
 		$options = array(
@@ -145,7 +154,7 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			'keywords_ban'  => '',
 			'columns'       => '1',
 			'thumb'         => $thumb,
-			'default'       => '',
+			'default'       => $default_thumbnail,
 			'title'         => '',
 			'meta'          => 'yes',
 			'multiple_meta' => 'no',

--- a/includes/gutenberg/feedzy-rss-feeds-loop-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-loop-block.php
@@ -138,10 +138,15 @@ class Feedzy_Rss_Feeds_Loop_Block {
 
 			if (
 				'yes' === $thumb &&
-				isset( $attributes['fallbackImage'], $attributes['fallbackImage']['url'] ) &&
-				! empty( $attributes['fallbackImage']['url'] )
+				isset( $attributes['fallbackImage'], $attributes['fallbackImage']['id'] ) &&
+				! empty( $attributes['fallbackImage']['id'] )
 			) {
-				$default_thumbnail = $attributes['fallbackImage']['url'];
+				$image_id  = $attributes['fallbackImage']['id'];
+				$media_img = wp_get_attachment_image_src( $image_id );
+
+				if ( is_array( $media_img ) && ! empty( $media_img[0] ) ) {
+					$default_thumbnail = $media_img[0];
+				}
 			}
 		}
 
@@ -320,8 +325,14 @@ class Feedzy_Rss_Feeds_Loop_Block {
 			isset( $attributes['fallbackImage'], $attributes['fallbackImage']['url'] ) &&
 			! empty( $attributes['fallbackImage']['url'] )
 		) {
-			return $attributes['fallbackImage']['url'];
-		} elseif (
+			$image_id  = $attributes['fallbackImage']['id'];
+			$media_img = wp_get_attachment_image_src( $image_id );
+			if ( is_array( $media_img ) && ! empty( $media_img[0] ) ) {
+				return $media_img[0];
+			}
+		}
+		
+		if (
 			isset( $settings, $settings['general'], $settings['general']['default-thumbnail-id'] ) &&
 			! empty( $settings['general']['default-thumbnail-id'] )
 		) {

--- a/js/FeedzyBlock/inspector.js
+++ b/js/FeedzyBlock/inspector.js
@@ -12,7 +12,6 @@ import RadioImageControl from './radio-image-control/';
 import classnames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { MediaUpload } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	ExternalLink,
@@ -23,11 +22,9 @@ import {
 	Button,
 	ToggleControl,
 	SelectControl,
-	ResponsiveWrapper,
 	Dashicon,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { FallbackImageLoader } from '../FeedzyLoop/components/FallbackImageLoader';
 
 /**
  * Create an Inspector Controls wrapper Component
@@ -429,7 +426,22 @@ class Inspector extends Component {
 										{this.props.attributes.thumb !==
 											'auto' && (
 											<FallbackImageLoader
-												props={this.props}
+												imageValue={
+													this.props.attributes
+														.default
+												}
+												onChangeImage={
+													this.props.edit.onDefault
+												}
+												onRemoveImage={() =>
+													this.props.edit.onDefault(
+														undefined
+													)
+												}
+												label={__(
+													'Fallback image if no image is found.',
+													'feedzy-rss-feeds'
+												)}
 											/>
 										)}
 										<TextControl
@@ -938,77 +950,6 @@ class Inspector extends Component {
 			</Fragment>
 		);
 	}
-}
-
-function FallbackImageLoader({ props }) {
-	return (
-		<div className="feedzy-blocks-base-control">
-			<label
-				className="blocks-base-control__label"
-				htmlFor="inspector-media-upload"
-			>
-				{__('Fallback image if no image is found.', 'feedzy-rss-feeds')}
-			</label>
-			<MediaUpload
-				type="image"
-				id="inspector-media-upload"
-				value={props.attributes.default}
-				onSelect={props.edit.onDefault}
-				render={({ open }) => (
-					<Fragment>
-						{props.attributes.default !== undefined && (
-							<ResponsiveWrapper
-								naturalWidth={props.attributes.default.width}
-								naturalHeight={props.attributes.default.height}
-							>
-								<img
-									src={props.attributes.default.url}
-									alt={__(
-										'Featured image',
-										'feedzy-rss-feeds'
-									)}
-								/>
-							</ResponsiveWrapper>
-						)}
-
-						<HStack>
-							{props.attributes.default !== undefined && (
-								<Button
-									isLarge
-									isSecondary
-									onClick={() =>
-										props.setAttributes({
-											default: undefined,
-										})
-									}
-									style={{
-										marginTop: '10px',
-									}}
-								>
-									{__('Remove Image', 'feedzy-rss-feeds')}
-								</Button>
-							)}
-
-							<Button
-								isLarge
-								isPrimary
-								onClick={open}
-								style={{
-									marginTop: '10px',
-								}}
-								className={
-									props.attributes.default === undefined &&
-									'feedzy_image_upload'
-								}
-							>
-								{__('Upload Image', 'feedzy-rss-feeds')}
-							</Button>
-						</HStack>
-					</Fragment>
-				)}
-			/>
-		</div>
-	);
 }
 
 export default Inspector;

--- a/js/FeedzyLoop/block.json
+++ b/js/FeedzyLoop/block.json
@@ -57,7 +57,7 @@
 		},
 		"thumb": {
 			"type": "string",
-			"default": "auto"
+			"default": "yes"
 		},
 		"fallbackImage": {
 			"type": "object"

--- a/js/FeedzyLoop/block.json
+++ b/js/FeedzyLoop/block.json
@@ -55,6 +55,13 @@
 				}
 			}
 		},
+		"thumb": {
+			"type": "string",
+			"default": "auto"
+		},
+		"fallbackImage": {
+			"type": "object"
+		},
 		"conditions": {
 			"type": "object",
 			"properties": {

--- a/js/FeedzyLoop/block.json
+++ b/js/FeedzyLoop/block.json
@@ -57,7 +57,7 @@
 		},
 		"thumb": {
 			"type": "string",
-			"default": "yes"
+			"default": "auto"
 		},
 		"fallbackImage": {
 			"type": "object"

--- a/js/FeedzyLoop/components/FallbackImageLoader.jsx
+++ b/js/FeedzyLoop/components/FallbackImageLoader.jsx
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { MediaUpload } from '@wordpress/block-editor';
+import {
+	Button,
+	ResponsiveWrapper,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+export function FallbackImageLoader({
+	imageValue,
+	onChangeImage,
+	onRemoveImage,
+	label = __('Fallback image if no image is found.', 'feedzy-rss-feeds'),
+}) {
+	const handleSelect = (media) => {
+		const imageData = {
+			url: media.url,
+			width: media.width,
+			height: media.height,
+			id: media.id,
+		};
+		onChangeImage(imageData);
+	};
+
+	const handleRemove = () => {
+		onRemoveImage();
+	};
+
+	return (
+		<div className="feedzy-blocks-base-control">
+			<label
+				className="blocks-base-control__label"
+				htmlFor="inspector-media-upload"
+			>
+				{label}
+			</label>
+			<MediaUpload
+				type="image"
+				id="inspector-media-upload"
+				value={imageValue}
+				onSelect={handleSelect}
+				render={({ open }) => (
+					<Fragment>
+						{imageValue !== undefined && (
+							<ResponsiveWrapper
+								naturalWidth={imageValue.width}
+								naturalHeight={imageValue.height}
+							>
+								<img
+									src={imageValue.url}
+									alt={__(
+										'Featured image',
+										'feedzy-rss-feeds'
+									)}
+								/>
+							</ResponsiveWrapper>
+						)}
+
+						<HStack>
+							{imageValue !== undefined && (
+								<Button
+									isLarge
+									isSecondary
+									onClick={handleRemove}
+									style={{
+										marginTop: '10px',
+									}}
+								>
+									{__('Remove Image', 'feedzy-rss-feeds')}
+								</Button>
+							)}
+
+							<Button
+								isLarge
+								isPrimary
+								onClick={open}
+								style={{
+									marginTop: '10px',
+								}}
+								className={
+									imageValue === undefined &&
+									'feedzy_image_upload'
+								}
+							>
+								{__('Upload Image', 'feedzy-rss-feeds')}
+							</Button>
+						</HStack>
+					</Fragment>
+				)}
+			/>
+		</div>
+	);
+}
+
+export default FallbackImageLoader;

--- a/js/FeedzyLoop/controls.js
+++ b/js/FeedzyLoop/controls.js
@@ -17,10 +17,13 @@ import {
 	BaseControl,
 } from '@wordpress/components';
 
+import { Fragment } from '@wordpress/element';
+
 /**
  * Internal dependencies.
  */
 import ConditionsControl from '../Conditions/ConditionsControl';
+import FallbackImageLoader from './components/FallbackImageLoader.jsx';
 
 const Controls = ({
 	attributes,
@@ -133,11 +136,67 @@ const Controls = ({
 						</Button>
 					</PanelBody>
 				)}
-
 				<PanelBody
-					title={[
-						__('Filter items', 'feedzy-rss-feeds'),
-					]}
+					title={__('Item Image Options', 'feedzy-rss-feeds')}
+					initialOpen={false}
+					className="feedzy-image-options"
+				>
+					<SelectControl
+						label={__(
+							'Display first image if available?',
+							'feedzy-rss-feeds'
+						)}
+						value={attributes.thumb}
+						options={[
+							{
+								label: __(
+									'Yes (without a fallback image)',
+									'feedzy-rss-feeds'
+								),
+								value: 'auto',
+							},
+							{
+								label: __(
+									'Yes (with a fallback image)',
+									'feedzy-rss-feeds'
+								),
+								value: 'yes',
+							},
+							{
+								label: __('No', 'feedzy-rss-feeds'),
+								value: 'no',
+							},
+						]}
+						onChange={(value) => setAttributes({ thumb: value })}
+						className="feedzy-thumb"
+					/>
+
+					{attributes?.thumb !== 'no' && (
+						<Fragment>
+							{attributes?.thumb !== 'auto' && (
+								<FallbackImageLoader
+									imageValue={attributes?.fallbackImage}
+									onChangeImage={(imageData) =>
+										setAttributes({
+											fallbackImage: imageData,
+										})
+									}
+									onRemoveImage={() =>
+										setAttributes({
+											fallbackImage: undefined,
+										})
+									}
+									label={__(
+										'Fallback image if no image is found.',
+										'feedzy-rss-feeds'
+									)}
+								/>
+							)}
+						</Fragment>
+					)}
+				</PanelBody>
+				<PanelBody
+					title={[__('Filter items', 'feedzy-rss-feeds')]}
 					initialOpen={false}
 					key="filters"
 					className="feedzy-item-filter"

--- a/js/FeedzyLoop/editor.scss
+++ b/js/FeedzyLoop/editor.scss
@@ -8,6 +8,11 @@
             width: 100%;
         }
     }
+
+    // Note: Hide generated invalid Core Image blocks
+    .wp-block-image:has( :is( img:not([src]), img[src=""] ) ) {
+        display: none;
+    }
 }
 
 .fz-condition-control {

--- a/js/FeedzyLoop/style.scss
+++ b/js/FeedzyLoop/style.scss
@@ -23,4 +23,9 @@
     .wp-block-image.is-style-rounded img {
         border-radius: 9999px;
     }
+
+    // Note: Hide generated invalid Core Image blocks
+    .wp-block-image:has( :is( img:not([src]), img[src=""] ) ) {
+        display: none;
+    }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1636,17 +1636,7 @@ parameters:
 			path: includes/gutenberg/feedzy-rss-feeds-loop-block.php
 
 		-
-			message: "#^Method Feedzy_Rss_Feeds_Loop_Block\\:\\:get_value\\(\\) has parameter \\$item with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: includes/gutenberg/feedzy-rss-feeds-loop-block.php
-
-		-
 			message: "#^Method Feedzy_Rss_Feeds_Loop_Block\\:\\:register_block\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: includes/gutenberg/feedzy-rss-feeds-loop-block.php
-
-		-
-			message: "#^Method Feedzy_Rss_Feeds_Loop_Block\\:\\:render_callback\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: includes/gutenberg/feedzy-rss-feeds-loop-block.php
 

--- a/tests/e2e/specs/loop.spec.js
+++ b/tests/e2e/specs/loop.spec.js
@@ -107,39 +107,156 @@ test.describe('Feedzy Loop', () => {
 		expect(feedzyLoopChildren.length).toBe(5);
 	});
 
-	test('check validation for invalid URL', async ({ editor, page, admin }) => {
+	test('check validation for invalid URL', async ({
+		editor,
+		page,
+		admin,
+	}) => {
 		await admin.createNewPost();
 
 		await editor.insertBlock({
 			name: 'feedzy-rss-feeds/loop',
 		});
 
-		await page.getByPlaceholder('Enter URLs or select a Feed').fill(
-			'http://invalid-url.com/feed'
-		);
+		await page
+			.getByPlaceholder('Enter URLs or select a Feed')
+			.fill('http://invalid-url.com/feed');
 		await page.getByRole('button', { name: 'Load Feed' }).click();
 
 		await page.waitForSelector('.feedzy-validation-results');
 
-		await expect( page.locator('.feedzy-validation-results .is-error').getByText('http://invalid-url.com/feed', { exact: true }) ).toBeVisible();
+		await expect(
+			page
+				.locator('.feedzy-validation-results .is-error')
+				.getByText('http://invalid-url.com/feed', { exact: true })
+		).toBeVisible();
 	});
 
-	test('check validation for invalid and valid url', async ({ editor, page, admin }) => {
+	test('check validation for invalid and valid url', async ({
+		editor,
+		page,
+		admin,
+	}) => {
 		await admin.createNewPost();
 
 		await editor.insertBlock({
 			name: 'feedzy-rss-feeds/loop',
 		});
 
-		await page.getByPlaceholder('Enter URLs or select a Feed').fill(
-			'http://invalid-url.com/feed, https://www.nasa.gov/feeds/iotd-feed/'
-		);
+		await page
+			.getByPlaceholder('Enter URLs or select a Feed')
+			.fill(
+				'http://invalid-url.com/feed, https://www.nasa.gov/feeds/iotd-feed/'
+			);
 		await page.getByRole('button', { name: 'Load Feed' }).click();
 
 		await page.waitForSelector('.feedzy-validation-results');
 
-		await expect( page.locator('.feedzy-validation-results .is-error').getByText('http://invalid-url.com/feed', { exact: true }) ).toBeVisible();
+		await expect(
+			page
+				.locator('.feedzy-validation-results .is-error')
+				.getByText('http://invalid-url.com/feed', { exact: true })
+		).toBeVisible();
 
-		await expect( page.locator('.feedzy-validation-results .is-success').getByText('https://www.nasa.gov/feeds/iotd-feed/', { exact: true }) ).toBeVisible();
+		await expect(
+			page
+				.locator('.feedzy-validation-results .is-success')
+				.getByText('https://www.nasa.gov/feeds/iotd-feed/', {
+					exact: true,
+				})
+		).toBeVisible();
+	});
+
+	test('check thumbnail display', async ({ editor, page, admin }) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'feedzy-rss-feeds/loop',
+			attributes: {
+				feed: {
+					type: 'url',
+					source: 'https://www.nasa.gov/feeds/iotd-feed/',
+				},
+				query: {
+					max: 1,
+				},
+			},
+		});
+
+		await page
+			.getByLabel('Display curated RSS content')
+			.click({ force: true });
+
+		await page.waitForSelector('.feedzy-loop-columns-1');
+
+		expect(
+			await page
+				.locator(`.wp-block-feedzy-rss-feeds-loop img[src*="https"]`)
+				.count()
+		).toBeGreaterThan(0);
+	});
+
+	test('check no thumbnail display', async ({ editor, page, admin }) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'feedzy-rss-feeds/loop',
+			attributes: {
+				feed: {
+					type: 'url',
+					source: 'https://www.nasa.gov/feeds/iotd-feed/',
+				},
+				query: {
+					max: 1,
+				},
+				thumb: 'no',
+			},
+		});
+
+		await page
+			.getByLabel('Display curated RSS content')
+			.click({ force: true });
+
+		await page.waitForSelector('.feedzy-loop-columns-1');
+
+		expect(
+			await page
+				.locator(`.wp-block-feedzy-rss-feeds-loop img[src*="https"]`)
+				.count()
+		).toBe(0);
+	});
+
+	test('check default SVG thumbnail display', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'feedzy-rss-feeds/loop',
+			attributes: {
+				feed: {
+					type: 'url',
+					source: 'https://fasterthanli.me/index.xml',
+				},
+				query: {
+					max: 1,
+				},
+				thumb: 'yes',
+			},
+		});
+
+		await page
+			.getByLabel('Display curated RSS content')
+			.click({ force: true });
+
+		await page.waitForSelector('.feedzy-loop-columns-1');
+
+		expect(
+			await page
+				.locator(`.wp-block-feedzy-rss-feeds-loop img[src*=".svg"]`)
+				.count()
+		).toBeGreaterThan(0);
 	});
 });


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add Fallback Image per block for Feedzy Loop

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="3434" height="1724" alt="CleanShot 2025-08-18 at 17 39 41@2x" src="https://github.com/user-attachments/assets/d291658b-46b7-4a35-8370-293efad265c1" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Insert a Feedzy Loop
- Use a feed without an image or mixed (https://markteam.s3-tastewp.com/feed/)
- Check if the fallback image is displayed on both the editor and the frontend

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/832
<!-- Should look like this: `Closes #1, #2, #3.` . -->
