### PR TITLE
refactor: apply forced HTTPS only to feed img

### DIFF
--- a/js/FeedzyBlock/Editor.js
+++ b/js/FeedzyBlock/Editor.js
@@ -311,8 +311,6 @@ class Editor extends Component {
 
 	getImageURL(item, background) {
 		let url;
-		window.console.log(this.props.attributes);
-		window.console.log(item);
 		if (
 			item.thumbnail &&
 			this.props.attributes.thumb === 'auto' &&


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fix the error where the fallback image wasn't set correctly
### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/18919d84-06fa-42b8-b3bd-2b8c82b3fe2e



<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/910
<!-- Should look like this: `Closes #1, #2, #3.` . -->
