### PR TITLE
fix: tsdk_banner position & visibility

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -118,7 +118,7 @@
 	display: none;
 }
 
-:is(.feedzy-banner, .feedzy-banner-dashboard):not(.themeisle-sale) {
+:is(.feedzy-banner, .feedzy-banner-dashboard):not(#tsdk_banner) {
 	visibility: hidden;
 }
 
@@ -134,6 +134,10 @@
 .feedzy-banner .themeisle-sale {
 	width: 100%;
 	margin: 0;
+}
+
+.feedzy-container > #tsdk_banner {
+	padding: 0;
 }
 
 .feedzy-container{

--- a/includes/layouts/feedzy-support.php
+++ b/includes/layouts/feedzy-support.php
@@ -17,6 +17,7 @@ $subscribed_notice_dismissed = get_option( 'feedzy_dismiss_subscribe_notice_dash
 	
 	?>
 	<div class="feedzy-container">
+		<div id="tsdk_banner" class="feedzy-banner"></div>
 		<div class="feedzy-accordion-item mb-30">
 			<div class="feedzy-accordion-item__content">
 				<div class="fz-tabs-menu">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Improve the positioning of the BF banner in the main dashboard page.
- Update the visiblity condition to correctly match the BF banner.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="4724" height="2566" alt="CleanShot 2025-11-03 at 16 06 57@2x" src="https://github.com/user-attachments/assets/f07e9178-9d53-4289-a4c8-8acbcba6a97e" />
<img width="4490" height="2510" alt="CleanShot 2025-11-03 at 16 07 06@2x" src="https://github.com/user-attachments/assets/f2d43161-9820-47fc-864b-3d5308d032bc" />
<img width="4782" height="2558" alt="CleanShot 2025-11-03 at 16 07 14@2x" src="https://github.com/user-attachments/assets/9914f863-940f-4630-8ec1-0237a53fa88d" />
<img width="4816" height="1902" alt="CleanShot 2025-11-03 at 16 07 22@2x" src="https://github.com/user-attachments/assets/f5fd2e5a-e866-4564-bafd-6f6f491073db" />
<img width="4828" height="2468" alt="CleanShot 2025-11-03 at 16 07 32@2x" src="https://github.com/user-attachments/assets/f40f8b83-fe2b-4550-ba06-27f3eeecc850" />
<img width="4812" height="2576" alt="CleanShot 2025-11-03 at 16 07 50@2x" src="https://github.com/user-attachments/assets/746332e7-5ab7-4bb8-b8f7-b6334fd361e5" />



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Set the date to Black Friday period. (You can use https://github.com/Soare-Robert-Daniel/test-black-friday?tab=readme-ov-file )
- Check the banner.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1825
<!-- Should look like this: `Closes #1, #2, #3.` . -->
