### PR TITLE
Fixed deprecated notice

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -858,7 +858,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 		require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 
-		$feed->set_file_class( 'WP_SimplePie_File' );
+		$feed->get_registry( 'WP_SimplePie_File' );
 		$default_agent = $this->get_default_user_agent( $feed_url );
 		$feed->set_useragent( apply_filters( 'http_headers_useragent', $default_agent ) );
 		if ( false === apply_filters( 'feedzy_disable_db_cache', false, $feed_url ) ) {

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -858,7 +858,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 		require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 
-		$feed->get_registry( 'WP_SimplePie_File' );
+		$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File' );
 		$default_agent = $this->get_default_user_agent( $feed_url );
 		$feed->set_useragent( apply_filters( 'http_headers_useragent', $default_agent ) );
 		if ( false === apply_filters( 'feedzy_disable_db_cache', false, $feed_url ) ) {

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -858,7 +858,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 		require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 
-		$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File' );
+		$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File', true );
 		$default_agent = $this->get_default_user_agent( $feed_url );
 		$feed->set_useragent( apply_filters( 'http_headers_useragent', $default_agent ) );
 		if ( false === apply_filters( 'feedzy_disable_db_cache', false, $feed_url ) ) {

--- a/tests/e2e/specs/classic-block.spec.js
+++ b/tests/e2e/specs/classic-block.spec.js
@@ -21,7 +21,7 @@ test.describe('Feedzy Classic Block', () => {
 
 		await page.getByRole('button', { name: 'Load Feed' }).click();
 
-		await page.waitForSelector('.feedzy-validation-results');
+		await page.waitForSelector('.feedzy-validation-results', { timeout: 30000 });
 
 		await expect(
 			page
@@ -49,7 +49,7 @@ test.describe('Feedzy Classic Block', () => {
 
 		await page.getByRole('button', { name: 'Load Feed' }).click();
 
-		await page.waitForSelector('.feedzy-validation-results');
+		await page.waitForSelector('.feedzy-validation-results', { timeout: 30000 });
 
 		await expect(
 			page

--- a/tests/e2e/specs/loop.spec.js
+++ b/tests/e2e/specs/loop.spec.js
@@ -119,7 +119,7 @@ test.describe('Feedzy Loop', () => {
 			.fill('http://invalid-url.com/feed');
 		await page.getByRole('button', { name: 'Load Feed' }).click();
 
-		await page.waitForSelector('.feedzy-validation-results');
+		await page.waitForSelector('.feedzy-validation-results', { timeout: 30000 });
 
 		await expect(
 			page
@@ -146,7 +146,7 @@ test.describe('Feedzy Loop', () => {
 			);
 		await page.getByRole('button', { name: 'Load Feed' }).click();
 
-		await page.waitForSelector('.feedzy-validation-results');
+		await page.waitForSelector('.feedzy-validation-results', { timeout: 30000 });
 
 		await expect(
 			page


### PR DESCRIPTION
### Summary
Call the `get_registry` function instead of `set_file_class`.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1174