### PR TITLE
Fixed php warning

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -446,11 +446,11 @@ class Feedzy_Rss_Feeds_Import {
 
 		$import_post_type = get_post_meta( $post->ID, 'import_post_type', true );
 		$import_post_term = get_post_meta( $post->ID, 'import_post_term', true );
-		if ( metadata_exists( $import_post_type, $post->ID, 'import_post_status' ) ) {
-			$import_post_status = get_post_meta( $post->ID, 'import_post_status', true );
-		} else {
-			add_post_meta( $post->ID, 'import_post_status', 'publish' );
-			$import_post_status = get_post_meta( $post->ID, 'import_post_status', true );
+
+		$import_post_status = get_post_meta( $post->ID, 'import_post_status', true );
+		if ( empty( $import_post_status ) ) {
+			$import_post_status = 'publish';
+			update_post_meta( $post->ID, 'import_post_status', $import_post_status );
 		}
 		$source                   = get_post_meta( $post->ID, 'source', true );
 		$inc_key                  = get_post_meta( $post->ID, 'inc_key', true );


### PR DESCRIPTION
### Summary
Call the `get_post_meta` function to get the metadata instead of the `metadata_exists` function, as its `meta_type` accepts arguments as object type with an associated meta table.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/937#issuecomment-3675429441