### PR TITLE
Removed banner support.

### DIFF
--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -88,10 +88,6 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 					return;
 				}
 
-				if ( in_array( $page_slug, array( 'imports', 'categories' ), true ) ) {
-					$this->add_banner_anchor();
-				}
-
 				if (
 					in_array( $page_slug, array( 'imports', 'new-category', 'settings' ), true )
 					&& 'yes' === get_option( 'feedzy_rss_feeds_logger_flag', false )
@@ -2735,21 +2731,6 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		return $survey_data;
-	}
-
-	/**
-	 * Add banner anchor for promotions.
-	 *
-	 * @return void
-	 */
-	public function add_banner_anchor() {
-		add_action(
-			'admin_notices',
-			function () {
-				echo '<div id="tsdk_banner" class="notice fz-notice feedzy-banner-dashboard"></div>';
-			},
-			999
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Removed Black Friday banner support to fix the empty banner notice, as we’ve implemented the Black Friday notice separately [here](https://github.com/Codeinwp/feedzy-rss-feeds/pull/1069)

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1181