### PR TITLE
Handled feed limit for non-pro users

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1614,7 +1614,7 @@ class Feedzy_Rss_Feeds_Import {
 		$import_featured_img      = get_post_meta( $job->ID, 'import_post_featured_img', true );
 		$import_post_type         = get_post_meta( $job->ID, 'import_post_type', true );
 		$import_post_term         = get_post_meta( $job->ID, 'import_post_term', true );
-		$import_feed_limit        = get_post_meta( $job->ID, 'import_feed_limit', true );
+		$import_feed_limit        = feedzy_is_pro() ? get_post_meta( $job->ID, 'import_feed_limit', true ) : '';
 		$import_item_img_url      = get_post_meta( $job->ID, 'import_use_external_image', true );
 		$import_remove_duplicates = get_post_meta( $job->ID, 'import_remove_duplicates', true );
 		$import_selected_language = get_post_meta( $job->ID, 'language', true );

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1627,9 +1627,13 @@ class Feedzy_Rss_Feeds_Import {
 		$import_post_author       = get_post_meta( $job->ID, 'import_post_author', true );
 		$mark_duplicate_tag       = get_post_meta( $job->ID, 'mark_duplicate_tag', true );
 		$mark_duplicate_tag       = feedzy_is_pro() && ! empty( $mark_duplicate_tag ) ? preg_replace( '/[\[\]#]/', '', $mark_duplicate_tag ) : '';
-		$max                      = $import_feed_limit;
+		$import_max               = $import_feed_limit;
 		$import_remove_html       = get_post_meta( $job->ID, 'import_remove_html', true );
 		$import_order             = get_post_meta( $job->ID, 'import_order', true );
+
+		if ( ! defined( 'TI_UNIT_TESTING' ) ) {
+			$max = $import_max;
+		}
 
 		Feedzy_Rss_Feeds_Log::info(
 			'Running import job: ' . $job->post_title . ' (ID: ' . $job->ID . ')',


### PR DESCRIPTION
### Summary
Checked is pro version is running or not; if not, fetch the 5 feed items only for non-pro users.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/951