### PR TITLE
Make http_headers_useragent filter compatible with WP

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -822,10 +822,10 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 * @since   3.1.7
 	 * @access  private
 	 *
-	 * @param   string $feed_url The feed URL.
-	 * @param   string $cache The cache string (eg. 1_hour, 30_min etc.).
-	 * @param   array  $sc The shortcode attributes.
-	 * @param   bool   $allow_https Defaults to constant FEEDZY_ALLOW_HTTPS.
+	 * @param   string|array<string> $feed_url The feed URL.
+	 * @param   string               $cache The cache string (eg. 1_hour, 30_min etc.).
+	 * @param   array                $sc The shortcode attributes.
+	 * @param   bool                 $allow_https Defaults to constant FEEDZY_ALLOW_HTTPS.
 	 *
 	 * @return SimplePie
 	 */

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -860,7 +860,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 		$feed->set_file_class( 'WP_SimplePie_File' );
 		$default_agent = $this->get_default_user_agent( $feed_url );
-		$feed->set_useragent( apply_filters( 'http_headers_useragent', $default_agent ) );
+		$feed->set_useragent( apply_filters( 'http_headers_useragent', $default_agent, is_array( $feed_url ) ? reset( $feed_url ) : $feed_url ) );
 		if ( false === apply_filters( 'feedzy_disable_db_cache', false, $feed_url ) ) {
 			SimplePie_Cache::register( 'wp_transient', 'WP_Feed_Cache_Transient' );
 			$feed->set_cache_location( 'wp_transient' );
@@ -917,7 +917,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
 			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
 			$set_server_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) . SIMPLEPIE_USERAGENT );
-			$feed->set_useragent( apply_filters( 'http_headers_useragent', $set_server_agent ) );
+			$feed->set_useragent( apply_filters( 'http_headers_useragent', $set_server_agent, is_array( $feed_url ) ? reset( $feed_url ) : $feed_url ) );
 		}
 
 		$feed->init();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,11 +271,6 @@ parameters:
 			path: includes/abstract/feedzy-rss-feeds-admin-abstract.php
 
 		-
-			message: "#^Parameter \\#1 \\$feed_url of method Feedzy_Rss_Feeds_Admin_Abstract\\:\\:init_feed\\(\\) expects string, array given\\.$#"
-			count: 2
-			path: includes/abstract/feedzy-rss-feeds-admin-abstract.php
-
-		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -297,17 +292,12 @@ parameters:
 
 		-
 			message: "#^Result of && is always false\\.$#"
-			count: 4
+			count: 2
 			path: includes/abstract/feedzy-rss-feeds-admin-abstract.php
 
 		-
 			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 3
-			path: includes/abstract/feedzy-rss-feeds-admin-abstract.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between 1 and \\*NEVER\\* will always evaluate to false\\.$#"
-			count: 2
+			count: 1
 			path: includes/abstract/feedzy-rss-feeds-admin-abstract.php
 
 		-


### PR DESCRIPTION
### Summary
Passed the URL to the `http_headers_useragent` filter to make it compatible with WordPress.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1186