### PR TITLE
Added fallback for media thumbnail retrieval

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1770,7 +1770,9 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		// xmlns:media thumbnail.
 		if ( empty( $the_thumbnail ) ) {
 			$data = $item->get_item_tags( 'http://search.yahoo.com/mrss/', 'thumbnail' );
-			if ( isset( $data['0']['data'] ) && ! empty( $data['0']['data'] ) ) {
+			if ( isset( $data['0']['attribs']['']['url'] ) && ! empty( $data['0']['attribs']['']['url'] ) ) {
+				$the_thumbnail = $data['0']['attribs']['']['url'];
+			} elseif ( isset( $data['0']['data'] ) && ! empty( $data['0']['data'] ) ) {
 				$the_thumbnail = $data['0']['data'];
 			}
 		}

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1767,6 +1767,13 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$the_thumbnail = $data['0']['attribs']['']['href'];
 			}
 		}
+		// xmlns:media thumbnail.
+		if ( empty( $the_thumbnail ) ) {
+			$data = $item->get_item_tags( 'http://search.yahoo.com/mrss/', 'thumbnail' );
+			if ( isset( $data['0']['data'] ) && ! empty( $data['0']['data'] ) ) {
+				$the_thumbnail = $data['0']['data'];
+			}
+		}
 		// Content image.
 		if ( empty( $the_thumbnail ) ) {
 			$feed_description  = $item->get_content();


### PR DESCRIPTION
### Summary
Added a fallback to retrieve media from the `thumbnail` tag for the RSS feed.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/957