### PR TITLE
Prevent authenticated users to import job

### DIFF
--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1854,6 +1854,10 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		$post_action = isset( $_POST['_action'] ) ? sanitize_text_field( wp_unslash( $_POST['_action'] ) ) : '';
 		$post_id     = isset( $_POST['id'] ) ? intval( $_POST['id'] ) : '';
 
+		if ( ! feedzy_current_user_can() ) {
+			wp_send_json_error( array( 'msg' => __( 'You do not have permission to do this.', 'feedzy-rss-feeds' ) ), 403 );
+		}
+
 		switch ( $post_action ) {
 			case 'validate_clean':
 				// remove invalid URLs from this category.

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1259,6 +1259,10 @@ class Feedzy_Rss_Feeds_Import {
 		$_POST['feedzy_category_meta_noncename'] = isset( $_POST['security'] ) ? sanitize_text_field( wp_unslash( $_POST['security'] ) ) : '';
 		$_action                                 = isset( $_POST['_action'] ) ? sanitize_text_field( wp_unslash( $_POST['_action'] ) ) : '';
 
+		if ( ! feedzy_current_user_can() ) {
+			wp_send_json_error( array( 'msg' => __( 'You do not have permission to do this.', 'feedzy-rss-feeds' ) ), 403 );
+		}
+
 		switch ( $_action ) {
 			case 'import_status':
 				$this->import_status();


### PR DESCRIPTION
### Summary
Prevent authorized user to import the job, executing, purging and log Clearing.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/967