### PR TITLE
Load modals only on feedzy screens

### DIFF
--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -445,6 +445,10 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 	 * Add modals for the plugin.
 	 */
 	public function add_modals() {
+		$screen = get_current_screen();
+		if ( empty( $screen ) || 'feedzy_imports' !== $screen->post_type ) {
+			return;
+		}
 		?>
 			<script type="text/javascript">
 				jQuery(function () {


### PR DESCRIPTION
### Summary
Add the modal only on the `feedzy_imports` post type screen page.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1187