### PR TITLE
Prevent reading properties of null

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1082,12 +1082,19 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	protected function check_valid_source( $url, $cache, $source_type = 'xml' ) {
 		global $post;
 
+		$post_id = 0;
+
 		// phpcs:disable WordPress.Security.NonceVerification
-		if ( null === $post && ! empty( $_POST['id'] ) ) {
+		if ( ! empty( $_POST['id'] ) ) {
 			$post_id = (int) $_POST['id'];
-		} else {
+		} elseif ( null !== $post ) {
 			$post_id = $post->ID;
 		}
+
+		if ( empty( $post_id ) ) {
+			return false;
+		}
+
 		$is_valid = true;
 		if ( 'amazon' === $source_type ) {
 			$amazon_api_errors = array();

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1091,10 +1091,6 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			$post_id = $post->ID;
 		}
 
-		if ( empty( $post_id ) ) {
-			return false;
-		}
-
 		$is_valid = true;
 		if ( 'amazon' === $source_type ) {
 			$amazon_api_errors = array();
@@ -1110,7 +1106,9 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$amazon_api_errors['source_type'] = '[' . __( 'Amazon Product Advertising API', 'feedzy-rss-feeds' ) . ']';
 				$amazon_api_errors['source']      = array( $url );
 				$amazon_api_errors['errors']      = $amazon_products->get_errors();
-				update_post_meta( $post_id, '__transient_feedzy_invalid_source_errors', $amazon_api_errors );
+				if ( empty( $post_id ) ) {
+					update_post_meta( $post_id, '__transient_feedzy_invalid_source_errors', $amazon_api_errors );
+				}
 				$is_valid = false;
 			}
 		} else {
@@ -1122,7 +1120,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			if ( isset( $_POST['feedzy_meta_data']['import_link_author_admin'] ) && 'yes' === $_POST['feedzy_meta_data']['import_link_author_admin'] ) {
 				if ( $feed->get_items() ) {
 					$author = $feed->get_items()[0]->get_author();
-					if ( empty( $author ) ) {
+					if ( empty( $author ) && ! empty( $post_id ) ) {
 						update_post_meta( $post_id, '__transient_feedzy_invalid_dc_namespace', array( $url ) );
 						$is_valid = false;
 					}
@@ -1130,7 +1128,9 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 		}
 		// Update source type.
-		update_post_meta( $post_id, '__feedzy_source_type', $source_type );
+		if ( ! empty( $post_id ) ) {
+			update_post_meta( $post_id, '__feedzy_source_type', $source_type );
+		}
 
 		return $is_valid;
 	}


### PR DESCRIPTION
### Summary
Check the global `$post` variable and `$_POST['id']` to determine the post ID, ensuring we have a valid ID before proceeding with source validation.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1231