### PR TITLE
Improved import content pro options UI

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -2972,3 +2972,9 @@ button.feedzy-action-button {
 	cursor: auto;
 	line-height: 1.5;
 }
+
+.dropdown-menu .feedzy-pro {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}

--- a/css/settings.css
+++ b/css/settings.css
@@ -2976,5 +2976,6 @@ button.feedzy-action-button {
 .dropdown-menu .feedzy-pro {
 	display: flex;
 	align-items: center;
-	justify-content: center;
+	justify-content: space-between;
+ 	gap: 8px;
 }

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -3489,8 +3489,9 @@ class Feedzy_Rss_Feeds_Import {
 		}
 
 		if ( $disabled ) {
+			$default_tags .= '<hr>';
 			foreach ( $disabled as $tag => $label ) {
-				$default_tags .= '<span disabled title="' . __( 'Upgrade your license to use this tag', 'feedzy-rss-feeds' ) . '" class="dropdown-item">' . $label . ' -- <small>[#' . $tag . ']</small></span>';
+				$default_tags .= '<span disabled title="' . __( 'Upgrade your license to use this tag', 'feedzy-rss-feeds' ) . '" class="dropdown-item feedzy-pro"><span>' . $label . ' -- <small>[#' . $tag . ']</small></span><span class="pro-label">PRO</span></span>';
 			}
 		}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -3489,7 +3489,7 @@ class Feedzy_Rss_Feeds_Import {
 		}
 
 		if ( $disabled ) {
-			$default_tags .= '<hr>';
+			$default_tags .= '<hr/>';
 			foreach ( $disabled as $tag => $label ) {
 				$default_tags .= '<span disabled title="' . __( 'Upgrade your license to use this tag', 'feedzy-rss-feeds' ) . '" class="dropdown-item feedzy-pro"><span>' . $label . ' -- <small>[#' . $tag . ']</small></span><span class="pro-label">PRO</span></span>';
 			}


### PR DESCRIPTION
### Summary
Improved the display of upsell options.

## Screenshot
<img width="476" height="501" alt="image" src="https://github.com/user-attachments/assets/304a88af-4178-490a-83e6-0943d314485d" />


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/859