### PR TITLE
Clear and reschedule cron jobs before running import jobs

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1420,11 +1420,11 @@ class Feedzy_Rss_Feeds_Import {
 		// If the job has a scheduled event, clear it before running the job to avoid conflicts.
 		$job_id_int          = (int) $job_id;
 		$cron_args           = array( 100, $job_id_int );
- 		$next_scheduled_time = false;
+		$next_scheduled_time = false;
 		if ( ! empty( $job_id_int ) ) {
 			$next_scheduled_time = Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args );
- 			if ( $next_scheduled_time ) {
- 				Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron', $cron_args );
+			if ( $next_scheduled_time ) {
+				Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron', $cron_args );
 			}
 		}
 
@@ -1432,13 +1432,13 @@ class Feedzy_Rss_Feeds_Import {
 		if ( ! empty( $job_id_int ) && $next_scheduled_time ) {
 			$fz_cron_schedule = get_post_meta( $job_id_int, 'fz_cron_schedule', true );
 			$schedules        = wp_get_schedules();
- 			$interval         = isset( $schedules[ $fz_cron_schedule ]['interval'] ) ? (int) $schedules[ $fz_cron_schedule ]['interval'] : 0;
- 			if ( ! empty( $fz_cron_schedule ) && $interval > 0 && false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args ) ) {
- 				$next_time = time() + $interval;
- 				if ( is_numeric( $next_scheduled_time ) && (int) $next_scheduled_time > time() ) {
- 					$next_time = (int) $next_scheduled_time + $interval;
- 				}
- 				Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $next_time, $fz_cron_schedule, 'feedzy_cron', $cron_args );
+			$interval         = isset( $schedules[ $fz_cron_schedule ]['interval'] ) ? (int) $schedules[ $fz_cron_schedule ]['interval'] : 0;
+			if ( ! empty( $fz_cron_schedule ) && $interval > 0 && false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args ) ) {
+				$next_time = time() + $interval;
+				if ( is_numeric( $next_scheduled_time ) && (int) $next_scheduled_time > time() ) {
+					$next_time = (int) $next_scheduled_time + $interval;
+				}
+				Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $next_time, $fz_cron_schedule, 'feedzy_cron', $cron_args );
 			}
 		}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1419,22 +1419,26 @@ class Feedzy_Rss_Feeds_Import {
 
 		// If the job has a scheduled event, clear it before running the job to avoid conflicts.
 		$job_id_int          = (int) $job_id;
-		$had_scheduled_event = false;
+		$cron_args           = array( 100, $job_id_int );
+ 		$next_scheduled_time = false;
 		if ( ! empty( $job_id_int ) ) {
-			$had_scheduled_event = (bool) Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', array( 100, $job_id_int ) );
-			if ( $had_scheduled_event ) {
-				Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron', array( 100, $job_id_int ) );
+			$next_scheduled_time = Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args );
+ 			if ( $next_scheduled_time ) {
+ 				Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron', $cron_args );
 			}
 		}
 
-		// If the job had a scheduled event, reschedule it before running the job to maintain its schedule.
-		if ( ! empty( $job_id_int ) && $had_scheduled_event ) {
+		// If the job had a scheduled event, reschedule it for the next recurrence to keep the original cadence.
+		if ( ! empty( $job_id_int ) && $next_scheduled_time ) {
 			$fz_cron_schedule = get_post_meta( $job_id_int, 'fz_cron_schedule', true );
-			if ( ! empty( $fz_cron_schedule ) && false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', array( 100, $job_id_int ) ) ) {
-				$schedules = wp_get_schedules();
-				$interval  = isset( $schedules[ $fz_cron_schedule ]['interval'] ) ? (int) $schedules[ $fz_cron_schedule ]['interval'] : 0;
-				$next_time = $interval > 0 ? time() + $interval : time() + 10;
-				Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $next_time, $fz_cron_schedule, 'feedzy_cron', array( 100, $job_id_int ) );
+			$schedules        = wp_get_schedules();
+ 			$interval         = isset( $schedules[ $fz_cron_schedule ]['interval'] ) ? (int) $schedules[ $fz_cron_schedule ]['interval'] : 0;
+ 			if ( ! empty( $fz_cron_schedule ) && $interval > 0 && false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args ) ) {
+ 				$next_time = time() + $interval;
+ 				if ( is_numeric( $next_scheduled_time ) && (int) $next_scheduled_time > time() ) {
+ 					$next_time = (int) $next_scheduled_time + $interval;
+ 				}
+ 				Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $next_time, $fz_cron_schedule, 'feedzy_cron', $cron_args );
 			}
 		}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1417,6 +1417,27 @@ class Feedzy_Rss_Feeds_Import {
 			)
 		);
 
+		// If the job has a scheduled event, clear it before running the job to avoid conflicts.
+		$job_id_int          = (int) $job_id;
+		$had_scheduled_event = false;
+		if ( ! empty( $job_id_int ) ) {
+			$had_scheduled_event = (bool) Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', array( 100, $job_id_int ) );
+			if ( $had_scheduled_event ) {
+				Feedzy_Rss_Feeds_Util_Scheduler::clear_scheduled_hook( 'feedzy_cron', array( 100, $job_id_int ) );
+			}
+		}
+
+		// If the job had a scheduled event, reschedule it before running the job to maintain its schedule.
+		if ( ! empty( $job_id_int ) && $had_scheduled_event ) {
+			$fz_cron_schedule = get_post_meta( $job_id_int, 'fz_cron_schedule', true );
+			if ( ! empty( $fz_cron_schedule ) && false === Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', array( 100, $job_id_int ) ) ) {
+				$schedules = wp_get_schedules();
+				$interval  = isset( $schedules[ $fz_cron_schedule ]['interval'] ) ? (int) $schedules[ $fz_cron_schedule ]['interval'] : 0;
+				$next_time = $interval > 0 ? time() + $interval : time() + 10;
+				Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( $next_time, $fz_cron_schedule, 'feedzy_cron', array( 100, $job_id_int ) );
+			}
+		}
+
 		$count = $this->run_job( $job, 100 );
 
 		$msg  = 0 < $count ? __( 'Successfully run!', 'feedzy-rss-feeds' ) : __( 'Nothing imported!', 'feedzy-rss-feeds' );


### PR DESCRIPTION
### Summary
Clear the scheduled job when an import is run immediately, and then reschedule it for the next scheduled run time. This prevents duplicate posts from being imported when the import is executed manually while the scheduled job is still pending or running.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR