### PR TITLE
Escaped attributes to prevent XSS

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -1450,7 +1450,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				$content .= sprintf(
 					$line_item,
 					wp_kses_post( $item['itemAttr'] ),
-					! empty( $item['item_img'] ) && 'no' !== $sc['thumb'] ? sprintf( '<div class="%s" style="%s">%s</div>', $item['item_img_class'], $item['item_img_style'], sprintf( $anchor1, esc_url( $item['item_url'] ), esc_attr( $item['item_url_target'] ), esc_attr( $item['item_url_follow'] ), $item['item_url_title'], $item['item_img_style'], $item['item_img'] ) ) : '',
+					! empty( $item['item_img'] ) && 'no' !== $sc['thumb'] ? sprintf( '<div class="%s" style="%s">%s</div>', esc_attr( $item['item_img_class'] ), esc_attr( $item['item_img_style'] ), sprintf( $anchor1, esc_url( $item['item_url'] ), esc_attr( $item['item_url_target'] ), esc_attr( $item['item_url_follow'] ), esc_attr( $item['item_url_title'] ), esc_attr( $item['item_img_style'] ), wp_kses_post( $item['item_img'] ) ) ) : '',
 					sprintf( $anchor2, esc_url( $item['item_url'] ), esc_attr( $item['item_url_target'] ), esc_attr( $item['item_url_follow'] ), wp_kses_post( $item['item_title'] ) ),
 					esc_attr( $item['item_content_class'] ),
 					esc_attr( $item['item_content_style'] ),

--- a/tests/e2e/specs/classic-block.spec.js
+++ b/tests/e2e/specs/classic-block.spec.js
@@ -83,7 +83,7 @@ test.describe('Feedzy Classic Block', () => {
 		const image = page.locator('.feedzy-rss .rss_image img');
 		await expect(image).toHaveAttribute(
 			'style',
-			'height:150px;width:150px;'
+			'height:150px;width:150px'
 		);
 	});
 


### PR DESCRIPTION
### Summary
Escaped attributes to prevent XSS vulnerabilities.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/988