### PR TITLE
fix: prevent default fallback image from entering the import pipeline

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -2035,7 +2035,8 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 				return $the_thumbnail;
 			}
 	
-			if ( ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) && ! empty( $sc['feeds'] ) ) {
+			// Import jobs (__jobID set) skip the display fallback image: it cannot be sideloaded (SVG); imports use the default_thumbnail_id setting instead.
+			if ( ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) && ! empty( $sc['feeds'] ) && empty( $sc['__jobID'] ) ) {
 				$feed_url      = $this->normalize_urls( $sc['feeds'] );
 				$the_thumbnail = ! empty( $the_thumbnail ) ? $the_thumbnail : apply_filters( 'feedzy_default_image', $sc['default'], $feed_url );
 			}

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -2711,7 +2711,7 @@ class Feedzy_Rss_Feeds_Import {
 							$img_success = $this->try_save_featured_image( $image_source_url, $new_post_id, $img_title, $import_info );
 
 							Feedzy_Rss_Feeds_Log::debug(
-								sprintf( 'Saved featured image for post ID %1$s: %2$s', $new_post_id, $image_source_url ),
+								sprintf( 'Tried to save featured image for post ID %1$s: %2$s. Success: %3$s', $new_post_id, $image_source_url, $img_success ? 'yes' : 'no' ),
 								array(
 									'job_id'           => $job->ID,
 									'image_source_url' => $image_source_url,

--- a/tests/test-admin-abstract.php
+++ b/tests/test-admin-abstract.php
@@ -624,4 +624,86 @@ class Test_Abstract_Admin extends WP_UnitTestCase {
             $this->assertEquals($expected, $result, "Failed for input: $input");
         }
     }
+
+	/**
+	 * Build a SimplePie item that has no image anywhere (enclosure, media, content, description).
+	 */
+	private function get_imageless_item() {
+		$feed = new SimplePie();
+		$feed->set_raw_data('<?xml version="1.0" encoding="UTF-8"?>
+			<rss version="2.0">
+				<channel>
+					<title>Test Feed</title>
+					<item>
+						<title>Item without image</title>
+						<link>https://example.com/article</link>
+						<description>Plain text, no image tag.</description>
+					</item>
+				</channel>
+			</rss>');
+		$feed->init();
+		$items = $feed->get_items();
+		return $items[0];
+	}
+
+	/**
+	 * During an import job the bundled default image (feedzy.svg) must NOT be used as
+	 * the item image: WordPress rejects SVG uploads, causing Media Library errors.
+	 * See https://github.com/Codeinwp/feedzy-rss-feeds/issues/1277.
+	 */
+	public function test_feedzy_retrieve_image_import_job_skips_default_image() {
+		$sc = array(
+			'feeds'    => 'https://example.com/feed',
+			'default'  => '',
+			'__jobID'  => 42,
+		);
+
+		$result = $this->feedzy_abstract->feedzy_retrieve_image( $this->get_imageless_item(), $sc );
+
+		$this->assertSame( '', $result, 'Import jobs must not fall back to the bundled default image' );
+	}
+
+	/**
+	 * Display contexts (shortcode/block rendering, no __jobID) keep the default image
+	 * fallback, where the bundled SVG is fine inside an <img> tag.
+	 */
+	public function test_feedzy_retrieve_image_display_keeps_default_image() {
+		$sc = array(
+			'feeds'   => 'https://example.com/feed',
+			'default' => '',
+		);
+
+		$result = $this->feedzy_abstract->feedzy_retrieve_image( $this->get_imageless_item(), $sc );
+
+		$this->assertSame( FEEDZY_ABSURL . 'img/feedzy.svg', $result, 'Display contexts must keep the default image fallback' );
+	}
+
+	/**
+	 * The import-job guard must only suppress the fallback, never a real item image.
+	 */
+	public function test_feedzy_retrieve_image_import_job_keeps_real_item_image() {
+		$feed = new SimplePie();
+		$feed->set_raw_data('<?xml version="1.0" encoding="UTF-8"?>
+			<rss version="2.0">
+				<channel>
+					<title>Test Feed</title>
+					<item>
+						<title>Item with image</title>
+						<enclosure url="https://example.com/real-image.jpg" type="image/jpeg" />
+					</item>
+				</channel>
+			</rss>');
+		$feed->init();
+		$items = $feed->get_items();
+
+		$sc = array(
+			'feeds'    => 'https://example.com/feed',
+			'default'  => '',
+			'__jobID'  => 42,
+		);
+
+		$result = $this->feedzy_abstract->feedzy_retrieve_image( $items[0], $sc );
+
+		$this->assertSame( 'https://example.com/real-image.jpg', $result, 'Import jobs must still use the real item image' );
+	}
 }

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -11,6 +11,92 @@
 class Test_Image_Import extends WP_UnitTestCase {
 
 	/**
+	 * End-to-end import of a feed whose items have no images: the bundled SVG default
+	 * must not be sideloaded, and the configured global fallback thumbnail must be used.
+	 * See https://github.com/Codeinwp/feedzy-rss-feeds/issues/1277.
+	 */
+	public function test_import_without_item_images_uses_fallback_thumbnail() {
+		// Serve a two-item, image-less feed for any HTTP request, recording requested URLs.
+		$requested_urls = array();
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$requested_urls ) {
+				$requested_urls[] = $url;
+				return array(
+					'headers'  => array( 'content-type' => 'application/rss+xml' ),
+					'body'     => '<?xml version="1.0" encoding="UTF-8"?>
+						<rss version="2.0"><channel><title>No Image Feed</title><link>http://feedzy.test</link><description>t</description>
+							<item><title>Imageless one</title><link>http://feedzy.test/1</link><description>Plain text.</description><guid>fz-1</guid></item>
+							<item><title>Imageless two</title><link>http://feedzy.test/2</link><description>Also plain.</description><guid>fz-2</guid></item>
+						</channel></rss>',
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+
+		// Configure a global fallback thumbnail.
+		$fallback_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/2004-07-22-DSC_0007.jpg' );
+		$settings    = get_option( 'feedzy-settings', array() );
+		$settings['general']['default-thumbnail-id'] = $fallback_id;
+		update_option( 'feedzy-settings', $settings );
+
+		// Create the import job.
+		$job_id = wp_insert_post(
+			array(
+				'post_title'  => 'No image import',
+				'post_type'   => 'feedzy_imports',
+				'post_status' => 'publish',
+			)
+		);
+		foreach ( array(
+			'source'                    => 'http://feedzy.test/feed.xml',
+			'import_post_title'         => '[#item_title]',
+			'import_post_date'          => '[#item_date]',
+			'import_post_content'       => '[#item_content]',
+			'import_post_featured_img'  => '[#item_image]',
+			'import_post_type'          => 'post',
+			'import_post_status'        => 'publish',
+			'import_use_external_image' => 'no',
+		) as $key => $value ) {
+			update_post_meta( $job_id, $key, $value );
+		}
+
+		$attachments_before = count( get_posts( array( 'post_type' => 'attachment', 'numberposts' => -1 ) ) );
+
+		// Fresh instance so free_settings picks up the option; run outside wp-cron/AJAX,
+		// like WP-CLI based cron runners (the path that leaked the SVG).
+		$import = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$import->run_cron( 100, $job_id );
+
+		$created = get_posts( array( 'post_type' => 'post', 'post_status' => 'publish', 'numberposts' => -1 ) );
+		$this->assertCount( 2, $created, 'Both feed items should be imported' );
+
+		foreach ( $created as $post ) {
+			$this->assertEquals( $fallback_id, get_post_thumbnail_id( $post->ID ), 'Imported post must use the fallback thumbnail' );
+		}
+
+		// No sideload happened: the bundled SVG (or anything else) was not uploaded.
+		$attachments_after = count( get_posts( array( 'post_type' => 'attachment', 'numberposts' => -1 ) ) );
+		$this->assertEquals( $attachments_before, $attachments_after, 'Import must not upload any image to the Media Library' );
+
+		$this->assertEmpty( get_post_meta( $job_id, 'import_errors', true ), 'Import must finish without errors' );
+
+		// No fallback image (bundled SVG or configured attachment) may be fetched over
+		// HTTP during the import: the only allowed request is the feed itself.
+		$non_feed_requests = array_filter(
+			$requested_urls,
+			function ( $url ) {
+				return 0 !== strpos( $url, 'http://feedzy.test/' );
+			}
+		);
+		$this->assertEmpty( $non_feed_requests, 'Import must not download any image for imageless items: ' . implode( ', ', $non_feed_requests ) );
+	}
+
+	/**
 	 * Test that the image import allows valid image URLs and logs errors for invalid ones.
 	 * Test introduced to cover this issue https://github.com/Codeinwp/feedzy-rss-feeds/issues/917.
 	 * @since 4.4.6

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -85,15 +85,15 @@ class Test_Image_Import extends WP_UnitTestCase {
 
 		$this->assertEmpty( get_post_meta( $job_id, 'import_errors', true ), 'Import must finish without errors' );
 
-		// No fallback image (bundled SVG or configured attachment) may be fetched over
-		// HTTP during the import: the only allowed request is the feed itself.
-		$non_feed_requests = array_filter(
+		// No fallback image may be fetched over HTTP during the import: neither the
+		// bundled SVG nor the configured fallback attachment (hosted on this site).
+		$fallback_requests = array_filter(
 			$requested_urls,
 			function ( $url ) {
-				return 0 !== strpos( $url, 'http://feedzy.test/' );
+				return false !== strpos( $url, 'feedzy.svg' ) || 0 === strpos( $url, home_url() );
 			}
 		);
-		$this->assertEmpty( $non_feed_requests, 'Import must not download any image for imageless items: ' . implode( ', ', $non_feed_requests ) );
+		$this->assertEmpty( $fallback_requests, 'Import must not download any fallback image for imageless items: ' . implode( ', ', $fallback_requests ) );
 	}
 
 	/**


### PR DESCRIPTION
Feed items without an image were getting the bundled display fallback (`img/feedzy.svg`) pushed into the import pipeline, which then tried to sideload it — WordPress rejects SVG uploads, so customer logs filled up with `Cannot upload the image to Media Library` (issue #1277). Imports now never use the display fallback and rely on the Fallback Featured Image setting instead.

## What changed

- **Fallback guard (`feedzy_retrieve_image()`)** — the `feedzy_default_image` fallback is skipped whenever `$sc['__jobID']` is set. Before, the only protection was the runtime sniffing inside `feedzy_define_default_image()` (`wp_doing_cron()`, the `run_now` AJAX check) plus a `REST_REQUEST` check — none of which hold for imports fired by WP-CLI-based runners, common on managed hosts. Now Run Now, wp-cron and CLI runners behave identically.

- **Imageless item, no fallback configured** — before: the SVG was downloaded, sideloading failed, and each item logged a Media Library error. After: no download, the post is imported with no featured image and the log says the image could not be found.

- **Imageless item, fallback configured** — before: the fallback attachment was re-downloaded over HTTP and sideloaded again for every item, creating duplicate media. After: the existing attachment is attached with `set_post_thumbnail()`, no HTTP request and no duplicate.

- **Filter conditions** — a `featured_image` condition on an import job evaluates the item's real image again; previously the injected fallback made every item look like it had one, so such conditions matched everything.

- **Display contexts** — shortcode, block and import preview carry no `__jobID`, so the default image still renders inside the `<img>` tag. Unchanged.

- **Debug log** — the `Saved featured image…` line fired even when the save failed; it now reports `Success: yes/no`.

> [!NOTE]
> The guard assumes every import run carries `__jobID` in its shortcode options, which `run_job()` sets for all core paths. A PRO path that assembles import options without routing through `run_job()` would bypass the guard and still leak the fallback — worth a check on the PRO side.

## Import flow

```mermaid
flowchart LR
    A[Feed item] --> B{Item has<br/>its own image?}
    B -- yes --> C[Sideload item image]
    B -- no --> D{Changed:<br/>__jobID set?}:::changed
    D -- "no: shortcode, block, preview" --> E[Render default image in img tag]
    D -- "yes: import job" --> F{Fallback thumbnail<br/>configured?}
    F -- yes --> G[set_post_thumbnail with existing attachment]
    F -- no --> H[Post imported without featured image]

    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## QA

Needs `manage_options` to reach the Feedzy settings, and a feed whose items have no images.

1. Set a fallback image: WP Admin → Feedzy → Settings → General tab (`/wp-admin/admin.php?page=feedzy-settings`) → **Fallback Featured Image Settings** → *Choose image* → pick a JPG or PNG → **Save Settings**.
   **Expect:** a thumbnail preview of the chosen image appears under the setting after the page reloads.

2. Turn on debug logging: WP Admin → Feedzy → Settings → Schedules tab (`/wp-admin/admin.php?page=feedzy-settings&tab=schedules`) → **Logging Level** → `Debug` → **Save Settings**.
   **Expect:** the select still shows `Debug` after the reload.

3. Create the job: WP Admin → Feedzy → Import Posts → **New Import** (`/wp-admin/post-new.php?post_type=feedzy_imports`), set the imageless feed as source, map **Featured Image** to `[#item_image]`, leave *Use external image* off, publish. Note the job ID from the post URL.
   **Expect:** the job is listed under Import Posts.

4. Run it the way a managed host does — off-request, outside AJAX and wp-cron (this is the path that leaked the SVG):
   ```bash
   wp eval 'do_action( "feedzy_cron", 100, <JOB_ID> );'
   ```
   **Expect:** the command finishes without errors and the items appear under WP Admin → Posts.

5. Open two or three of the imported posts and check WP Admin → Media → Library.
   **Expect:** every post shows the fallback image from step 1 as its featured image, and the Media Library has no new attachments — no `feedzy.svg`, no duplicate copies of the fallback image.

6. Check WP Admin → Feedzy → Settings → Logs tab (`/wp-admin/admin.php?page=feedzy-settings&tab=logs`) → **Recent Logs**.
   **Expect:** no `Cannot upload the image to Media Library` entries and no mention of `feedzy.svg`.

7. Remove the fallback: General tab → *Remove* → **Save Settings**. Trash the imported posts and empty the trash, then re-run the command from step 4.
   **Expect:** posts import with no featured image, logs report the image could not be found, and there are still no Media Library upload errors.

8. Regression on display: put `[feedzy-rss feeds="<FEED URL>" thumb="yes"]` on a page (or add a Feedzy block) and view it on the front end.
   **Expect:** imageless items still show a default image — the bundled Feedzy logo while no fallback is configured, the chosen image once step 1 is redone.
