### PR TITLE
Added URL validation for HTTP requests to prevent SSRF

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -777,55 +777,57 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	public function fetch_feed( $feed_url, $cache = '12_hours', $sc = '' ) {
 		// Load SimplePie if not already.
 		do_action( 'feedzy_pre_http_setup', $feed_url );
-		if ( function_exists( 'feedzy_amazon_get_locale_hosts' ) ) {
-			$amazon_hosts     = feedzy_amazon_get_locale_hosts();
-			$is_amazon_source = false;
-			if ( is_array( $feed_url ) ) {
-				$url_host         = array_map(
-					function ( $url ) {
-						return 'webservices.' . wp_parse_url( $url, PHP_URL_HOST );
-					},
-					$feed_url
-				);
-				$url_host         = array_diff( $url_host, $amazon_hosts );
-				$is_amazon_source = ! empty( $amazon_hosts ) && empty( $url_host );
-			} else {
-				$url_host         = 'webservices.' . wp_parse_url( $feed_url, PHP_URL_HOST );
-				$is_amazon_source = ! empty( $amazon_hosts ) && in_array( $url_host, $amazon_hosts, true );
-			}
-			if ( $is_amazon_source ) {
-				$feed = $this->init_amazon_api(
-					$feed_url,
-					isset( $sc['refresh'] ) ? $sc['refresh'] : '12_hours',
-					array(
-						'number_of_item' => isset( $sc['max'] ) ? $sc['max'] : 5,
-						'no-cache'       => false,
-					)
-				);
-				return $feed;
-			}
-		}
-		// Load SimplePie Instance.
-		$feed = $this->init_feed( $feed_url, $cache, $sc ); // Not used as log as #41304 is Opened.
 
-		// Report error when is an error loading the feed.
-		if ( is_wp_error( $feed ) ) {
-			// Fallback for different edge cases.
-			if ( is_array( $feed_url ) ) {
-				$feed_url = array_map( 'html_entity_decode', $feed_url );
-			} else {
-				$feed_url = html_entity_decode( $feed_url );
+		try {
+			if ( function_exists( 'feedzy_amazon_get_locale_hosts' ) ) {
+				$amazon_hosts     = feedzy_amazon_get_locale_hosts();
+				$is_amazon_source = false;
+				if ( is_array( $feed_url ) ) {
+					$url_host         = array_map(
+						function ( $url ) {
+							return 'webservices.' . wp_parse_url( $url, PHP_URL_HOST );
+						},
+						$feed_url
+					);
+					$url_host         = array_diff( $url_host, $amazon_hosts );
+					$is_amazon_source = ! empty( $amazon_hosts ) && empty( $url_host );
+				} else {
+					$url_host         = 'webservices.' . wp_parse_url( $feed_url, PHP_URL_HOST );
+					$is_amazon_source = ! empty( $amazon_hosts ) && in_array( $url_host, $amazon_hosts, true );
+				}
+				if ( $is_amazon_source ) {
+					return $this->init_amazon_api(
+						$feed_url,
+						isset( $sc['refresh'] ) ? $sc['refresh'] : '12_hours',
+						array(
+							'number_of_item' => isset( $sc['max'] ) ? $sc['max'] : 5,
+							'no-cache'       => false,
+						)
+					);
+				}
 			}
-
-			$feed_url = $this->get_valid_source_urls( $feed_url, $cache );
-
+			// Load SimplePie Instance.
 			$feed = $this->init_feed( $feed_url, $cache, $sc ); // Not used as log as #41304 is Opened.
 
+			// Report error when is an error loading the feed.
+			if ( is_wp_error( $feed ) ) {
+				// Fallback for different edge cases.
+				if ( is_array( $feed_url ) ) {
+					$feed_url = array_map( 'html_entity_decode', $feed_url );
+				} else {
+					$feed_url = html_entity_decode( $feed_url );
+				}
+
+				$feed_url = $this->get_valid_source_urls( $feed_url, $cache );
+
+				$feed = $this->init_feed( $feed_url, $cache, $sc ); // Not used as log as #41304 is Opened.
+
+			}
+
+			return $feed;
+		} finally {
+			do_action( 'feedzy_post_http_teardown', $feed_url );
 		}
-
-		do_action( 'feedzy_post_http_teardown', $feed_url );
-
-		return $feed;
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -49,6 +49,14 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 	protected $version;
 
 	/**
+	 * Pinned resolve entries for cURL requests. Each entry is a string in the format "host:port:ip".
+	 *
+	 * @access   private
+	 * @var      array<string, string> $pinned_resolve
+	 */
+	private $pinned_resolve = array();
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since   3.0.0
@@ -1551,9 +1559,14 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
 		add_filter( 'http_request_args', array( $this, 'http_request_args' ) );
 
+		$this->pinned_resolve = array();
+
 		// Validate the request URL and any redirects to ensure they are publicly routable.
 		add_filter( 'pre_http_request', array( $this, 'validate_unsafe_request' ), 10, 3 );
 		add_action( 'requests-requests.before_redirect', array( $this, 'validate_redirect' ) );
+
+		// Pin the connection to a validated address if the request URL resolves to one or more publicly routable addresses.
+		add_action( 'http_api_curl', array( $this, 'pin_curl_resolve' ), 10, 3 );
 	}
 
 	/**
@@ -1586,7 +1599,8 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 	 *
 	 * @return void
 	 *
-	 * @throws \WpOrg\Requests\Exception When the redirect target is not safe.
+	 * @throws \WpOrg\Requests\Exception When the redirect target is not safe (WP 6.2+).
+	 * @throws \Requests_Exception When the redirect target is not safe (WP < 6.2).
 	 */
 	public function validate_redirect( $location ) {
 		if ( $this->is_safe_url( $location ) ) {
@@ -1594,8 +1608,16 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		// The Requests library does not provide a way to abort a request with a WP_Error,
-		// so we throw an exception instead.
-		throw new \WpOrg\Requests\Exception(
+		// so we throw an exception instead. WP < 6.2 bundles the pre-namespace Requests
+		// library, where this class is `Requests_Exception` instead.
+		if ( class_exists( '\WpOrg\Requests\Exception' ) ) {
+			throw new \WpOrg\Requests\Exception(
+				esc_html__( 'Invalid feed URL.', 'feedzy-rss-feeds' ),
+				'feedzy.unsafe_redirect'
+			);
+		}
+
+		throw new \Requests_Exception(
 			esc_html__( 'Invalid feed URL.', 'feedzy-rss-feeds' ),
 			'feedzy.unsafe_redirect'
 		);
@@ -1642,7 +1664,60 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 		}
 
+		// Pin the connection to the first resolved address, which is guaranteed to be publicly routable.
+		$this->pin_resolved_address( $host, $this->get_url_port( $parts, strtolower( $parts['scheme'] ) ), $ips[0] );
+
 		return true;
+	}
+
+	/**
+	 * Returns the port for a URL, defaulting to 80 for HTTP and 443 for HTTPS if not specified.
+	 *
+	 * @param array<string, mixed> $parts  The URL, as parsed by wp_parse_url().
+	 * @param string               $scheme The lowercased URL scheme.
+	 *
+	 * @return int
+	 */
+	private function get_url_port( array $parts, $scheme ) {
+		if ( ! empty( $parts['port'] ) ) {
+			return (int) $parts['port'];
+		}
+
+		return 'https' === $scheme ? 443 : 80;
+	}
+
+	/**
+	 * Pins a cURL connection to a validated address for a given host and port.
+	 *
+	 * @param string $host The hostname (not an IP literal).
+	 * @param int    $port The port the request will connect on.
+	 * @param string $ip   The validated address to pin the connection to.
+	 *
+	 * @return void
+	 */
+	private function pin_resolved_address( $host, $port, $ip ) {
+		$formatted_ip = ( false !== strpos( $ip, ':' ) ) ? '[' . $ip . ']' : $ip;
+
+		$this->pinned_resolve[ "{$host}:{$port}" ] = "{$host}:{$port}:{$formatted_ip}";
+	}
+
+	/**
+	 * Pins a cURL connection to a validated address if one has been recorded
+	 * for the request URL's host and port.
+	 *
+	 * @param resource             $handle      The cURL handle returned by curl_init() (passed by reference).
+	 * @param array<string, mixed> $parsed_args The HTTP request arguments.
+	 * @param string               $url         The request URL.
+	 *
+	 * @return void
+	 */
+	public function pin_curl_resolve( $handle, $parsed_args, $url ) {
+		if ( empty( $this->pinned_resolve ) || ! defined( 'CURLOPT_RESOLVE' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt
+		curl_setopt( $handle, CURLOPT_RESOLVE, array_values( $this->pinned_resolve ) );
 	}
 
 	/**
@@ -1659,27 +1734,29 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 
 		$ips = array();
 
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$a_records = @dns_get_record( $host, DNS_A );
-		if ( is_array( $a_records ) ) {
-			foreach ( $a_records as $record ) {
-				if ( ! empty( $record['ip'] ) ) {
-					$ips[] = $record['ip'];
+		if ( function_exists( 'dns_get_record' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$a_records = @dns_get_record( $host, DNS_A );
+			if ( is_array( $a_records ) ) {
+				foreach ( $a_records as $record ) {
+					if ( ! empty( $record['ip'] ) ) {
+						$ips[] = $record['ip'];
+					}
+				}
+			}
+
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$aaaa_records = @dns_get_record( $host, DNS_AAAA );
+			if ( is_array( $aaaa_records ) ) {
+				foreach ( $aaaa_records as $record ) {
+					if ( ! empty( $record['ipv6'] ) ) {
+						$ips[] = $record['ipv6'];
+					}
 				}
 			}
 		}
 
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$aaaa_records = @dns_get_record( $host, DNS_AAAA );
-		if ( is_array( $aaaa_records ) ) {
-			foreach ( $aaaa_records as $record ) {
-				if ( ! empty( $record['ipv6'] ) ) {
-					$ips[] = $record['ipv6'];
-				}
-			}
-		}
-
-		if ( empty( $ips ) ) {
+		if ( empty( $ips ) && function_exists( 'gethostbyname' ) ) {
 			$fallback = gethostbyname( $host );
 			if ( $fallback !== $host ) {
 				$ips[] = $fallback;
@@ -1861,6 +1938,8 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		remove_filter( 'http_headers_useragent', array( $this, 'add_user_agent' ) );
 		remove_filter( 'pre_http_request', array( $this, 'validate_unsafe_request' ), 10 );
 		remove_action( 'requests-requests.before_redirect', array( $this, 'validate_redirect' ) );
+		remove_action( 'http_api_curl', array( $this, 'pin_curl_resolve' ), 10 );
+		$this->pinned_resolve = array();
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1600,7 +1600,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 	 * @return void
 	 *
 	 * @throws \WpOrg\Requests\Exception When the redirect target is not safe (WP 6.2+).
-	 * @throws \Requests_Exception When the redirect target is not safe (WP < 6.2).
+	 * @throws \Exception When the redirect target is not safe (WP < 6.2).
 	 */
 	public function validate_redirect( $location ) {
 		if ( $this->is_safe_url( $location ) ) {
@@ -1617,7 +1617,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			);
 		}
 
-		throw new \Requests_Exception(
+		throw new \Exception(
 			esc_html__( 'Invalid feed URL.', 'feedzy-rss-feeds' ),
 			'feedzy.unsafe_redirect'
 		);

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1550,6 +1550,184 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 
 		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
 		add_filter( 'http_request_args', array( $this, 'http_request_args' ) );
+
+		// Validate the request URL and any redirects to ensure they are publicly routable.
+		add_filter( 'pre_http_request', array( $this, 'validate_unsafe_request' ), 10, 3 );
+		add_action( 'requests-requests.before_redirect', array( $this, 'validate_redirect' ) );
+	}
+
+	/**
+	 * Validates that a request URL is safe to request.
+	 *
+	 * @param false|array<string, mixed>|WP_Error $preempt Preemptive return value.
+	 * @param array<string, mixed>                $parsed_args HTTP request arguments.
+	 * @param string                              $url The request URL.
+	 * @return false|array<string, mixed>|WP_Error
+	 */
+	public function validate_unsafe_request( $preempt, $parsed_args, $url ) {
+		if ( false !== $preempt ) {
+			return $preempt;
+		}
+
+		if ( $this->is_safe_url( $url ) ) {
+			return false;
+		}
+
+		return new WP_Error(
+			'feedzy_unsafe_url',
+			__( 'Invalid feed URL.', 'feedzy-rss-feeds' )
+		);
+	}
+
+	/**
+	 * Aborts the request if a redirect points to a non-public URL.
+	 *
+	 * @param string $location The redirect destination.
+	 *
+	 * @return void
+	 *
+	 * @throws \WpOrg\Requests\Exception When the redirect target is not safe.
+	 */
+	public function validate_redirect( $location ) {
+		if ( $this->is_safe_url( $location ) ) {
+			return;
+		}
+
+		// The Requests library does not provide a way to abort a request with a WP_Error,
+		// so we throw an exception instead.
+		throw new \WpOrg\Requests\Exception(
+			esc_html__( 'Invalid feed URL.', 'feedzy-rss-feeds' ),
+			'feedzy.unsafe_redirect'
+		);
+	}
+
+	/**
+	 * Whether a URL uses an allowed scheme and every address its host
+	 * resolves to is publicly routable.
+	 *
+	 * @param string $url The URL to validate.
+	 *
+	 * @return bool
+	 */
+	private function is_safe_url( $url ) {
+		if ( ! is_string( $url ) || '' === trim( $url ) ) {
+			return false;
+		}
+
+		$parts = wp_parse_url( $url );
+
+		if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return false;
+		}
+
+		if ( ! in_array( strtolower( $parts['scheme'] ), array( 'http', 'https' ), true ) ) {
+			return false;
+		}
+
+		$host = strtolower( trim( $parts['host'], '.' ) );
+
+		if ( '' === $host || 'localhost' === $host ) {
+			return false;
+		}
+
+		$ips = $this->resolve_ips( $host );
+
+		if ( empty( $ips ) ) {
+			return false;
+		}
+
+		foreach ( $ips as $ip ) {
+			if ( ! $this->is_public_ip( $ip ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolves a hostname (or IP literal) to every IPv4/IPv6 address it maps to.
+	 *
+	 * @param string $host The hostname or IP literal.
+	 *
+	 * @return string[]
+	 */
+	private function resolve_ips( $host ) {
+		if ( false !== filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return array( $host );
+		}
+
+		$ips = array();
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$a_records = @dns_get_record( $host, DNS_A );
+		if ( is_array( $a_records ) ) {
+			foreach ( $a_records as $record ) {
+				if ( ! empty( $record['ip'] ) ) {
+					$ips[] = $record['ip'];
+				}
+			}
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$aaaa_records = @dns_get_record( $host, DNS_AAAA );
+		if ( is_array( $aaaa_records ) ) {
+			foreach ( $aaaa_records as $record ) {
+				if ( ! empty( $record['ipv6'] ) ) {
+					$ips[] = $record['ipv6'];
+				}
+			}
+		}
+
+		if ( empty( $ips ) ) {
+			$fallback = gethostbyname( $host );
+			if ( $fallback !== $host ) {
+				$ips[] = $fallback;
+			}
+		}
+
+		return $ips;
+	}
+
+	/**
+	 * Whether an IP address is publicly routable, i.e. not private,
+	 * loopback, link-local, multicast or otherwise reserved.
+	 *
+	 * @param string $ip The IP address.
+	 *
+	 * @return bool
+	 */
+	private function is_public_ip( $ip ) {
+		if ( false === filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return false;
+		}
+
+		return ! $this->is_multicast_ip( $ip );
+	}
+
+	/**
+	 * Whether an IP address is in a multicast range.
+	 *
+	 * @param string $ip The IP address.
+	 *
+	 * @return bool
+	 */
+	private function is_multicast_ip( $ip ) {
+		$packed = inet_pton( $ip );
+
+		if ( false === $packed ) {
+			return true;
+		}
+
+		$first_byte = ord( $packed[0] );
+
+		if ( 4 === strlen( $packed ) ) {
+			// IPv4 multicast: 224.0.0.0/4.
+			return $first_byte >= 224 && $first_byte <= 239;
+		}
+
+		// IPv6 multicast: ff00::/8.
+		return 0xff === $first_byte;
 	}
 
 	/**
@@ -1681,6 +1859,8 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 	 */
 	public function post_http_teardown( $url ) {
 		remove_filter( 'http_headers_useragent', array( $this, 'add_user_agent' ) );
+		remove_filter( 'pre_http_request', array( $this, 'validate_unsafe_request' ), 10 );
+		remove_action( 'requests-requests.before_redirect', array( $this, 'validate_redirect' ) );
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -1618,8 +1618,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		throw new \Exception(
-			esc_html__( 'Invalid feed URL.', 'feedzy-rss-feeds' ),
-			'feedzy.unsafe_redirect'
+			esc_html__( 'Invalid feed URL.', 'feedzy-rss-feeds' )
 		);
 	}
 


### PR DESCRIPTION
### Summary
Added filters in `pre_http_setup` to validate both the initial request URL and any redirects triggered by `requests-requests.before_redirect`. The new `validate_unsafe_request()` and `validate_redirect()` methods ensure that only publicly routable URLs are allowed by validating the URL scheme (`http`/`https`), host, and public IP address before the request or redirect is processed.

Additionally, the temporary hooks added for URL validation are removed after the HTTP request completes, ensuring no side effects remain for subsequent requests.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/1003