### PR TITLE
Enhanced permission checks for import actions

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -967,7 +967,7 @@ class Feedzy_Rss_Feeds_Import {
 				$msg .= $this->get_last_run_details( $post_id );
 				echo ( $msg ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-				if ( 'publish' === $post->post_status ) {
+				if ( 'publish' === $post->post_status && current_user_can( 'edit_post', $post_id ) ) {
 					printf( '<p><input type="button" class="button button-primary feedzy-run-now" data-id="%d" value="%s"></p>', esc_attr( $post_id ), esc_attr__( 'Run Now', 'feedzy-rss-feeds' ) );
 				}
 
@@ -1070,7 +1070,7 @@ class Feedzy_Rss_Feeds_Import {
 		$errors = $this->get_import_errors( $post_id );
 		// popup for errors found.
 		if ( ! empty( $errors ) ) {
-			$msg .= '<div class="feedzy-errors-found-' . $post_id . ' feedzy-errors-dialog" title="' . __( 'Errors', 'feedzy-rss-feeds' ) . '" data-id="' . $post_id . '">' . $errors . '</div>';
+			$msg .= '<div class="feedzy-errors-found-' . $post_id . ' feedzy-errors-dialog" title="' . __( 'Errors', 'feedzy-rss-feeds' ) . '" data-id="' . $post_id . '" data-can-manage="' . ( current_user_can( 'edit_post', $post_id ) ? '1' : '0' ) . '">' . $errors . '</div>';
 		}
 
 		// remember, cypress will work off the data-value attributes.
@@ -1295,6 +1295,34 @@ class Feedzy_Rss_Feeds_Import {
 	}
 
 	/**
+	 * Gets the import post if the ID is valid and the current user is authorized to manage it.
+	 *
+	 * @param int $import_id The import post ID.
+	 *
+	 * @return \WP_Post|false The import post on success, false if the ID is invalid or the
+	 *                        current user is not authorized to manage it.
+	 *
+	 * @access  private
+	 */
+	private function get_authorized_import( $import_id ) {
+		$import_id = (int) $import_id;
+		if ( empty( $import_id ) ) {
+			return false;
+		}
+
+		$import = get_post( $import_id );
+		if ( ! $import || 'feedzy_imports' !== $import->post_type ) {
+			return false;
+		}
+
+		if ( ! current_user_can( 'edit_post', $import_id ) ) {
+			return false;
+		}
+
+		return $import;
+	}
+
+	/**
 	 * AJAX called method to remove import upsell notice.
 	 *
 	 * @since   3.4.1
@@ -1328,7 +1356,11 @@ class Feedzy_Rss_Feeds_Import {
 
 		check_ajax_referer( FEEDZY_BASEFILE, 'security' );
 
-		$id      = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+		$id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+		if ( ! $this->get_authorized_import( $id ) ) {
+			wp_send_json_error( array( 'msg' => __( 'You do not have permission to do this.', 'feedzy-rss-feeds' ) ), 403 );
+		}
+
 		$status  = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : '';
 		$publish = 'draft';
 		// no activation till source is not valid.
@@ -1403,14 +1435,17 @@ class Feedzy_Rss_Feeds_Import {
 	 */
 	private function run_now() {
 		check_ajax_referer( FEEDZY_BASEFILE, 'security' );
-	
+
 		$job_id = filter_input( INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT );
-		$job    = get_post( $job_id );
+		$job    = $this->get_authorized_import( (int) $job_id );
+		if ( ! $job ) {
+			wp_send_json_error( array( 'msg' => __( 'You do not have permission to do this.', 'feedzy-rss-feeds' ) ), 403 );
+		}
 
 		Feedzy_Rss_Feeds_Log::info(
 			sprintf(
 				'Manual run for import: %s',
-				isset( $job->post_title ) ? $job->post_title : 'Unknown Job'
+				$job->post_title
 			),
 			array(
 				'job_id' => $job_id,
@@ -3904,11 +3939,13 @@ class Feedzy_Rss_Feeds_Import {
 			// don't need quick edit.
 			unset( $actions['inline hide-if-no-js'] );
 
-			$actions['feedzy_purge'] = sprintf(
-				'<a href="#" class="feedzy-purge" data-id="%d">%2$s</a>',
-				$post->ID,
-				esc_html( __( 'Purge &amp; Reset', 'feedzy-rss-feeds' ) )
-			);
+			if ( current_user_can( 'edit_post', $post->ID ) ) {
+				$actions['feedzy_purge'] = sprintf(
+					'<a href="#" class="feedzy-purge" data-id="%d">%2$s</a>',
+					$post->ID,
+					esc_html( __( 'Purge &amp; Reset', 'feedzy-rss-feeds' ) )
+				);
+			}
 
 			if ( feedzy_is_pro() ) {
 				$actions['feedzy_clone'] =
@@ -3987,9 +4024,8 @@ class Feedzy_Rss_Feeds_Import {
 
 		$id                 = filter_input( INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT );
 		$del_imported_posts = filter_input( INPUT_POST, 'del_imported_posts', FILTER_VALIDATE_BOOLEAN );
-		$post               = get_post( $id );
-		if ( 'feedzy_imports' !== $post->post_type ) {
-			wp_die();
+		if ( ! $this->get_authorized_import( (int) $id ) ) {
+			wp_send_json_error( array( 'msg' => __( 'You do not have permission to do this.', 'feedzy-rss-feeds' ) ), 403 );
 		}
 
 		// Delete imported posts.
@@ -4451,9 +4487,10 @@ class Feedzy_Rss_Feeds_Import {
 	private function clear_error_logs() {
 		check_ajax_referer( FEEDZY_BASEFILE, 'security' );
 		$id = ! empty( $_POST['id'] ) ? (int) $_POST['id'] : 0;
-		if ( $id ) {
-			delete_post_meta( $id, 'import_errors' );
+		if ( ! $this->get_authorized_import( $id ) ) {
+			wp_send_json_error( array( 'msg' => __( 'You do not have permission to do this.', 'feedzy-rss-feeds' ) ), 403 );
 		}
+		delete_post_meta( $id, 'import_errors' );
 		wp_send_json(
 			array(
 				'status' => 1,

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -289,24 +289,31 @@
 			status,
 		};
 
+		function showStatusError(message) {
+			if (message) {
+				// eslint-disable-next-line no-alert
+				window.alert(message);
+			}
+			// revert the toggle back to its state prior to this click.
+			toggle.prop('checked', !status);
+		}
+
 		showSpinner(toggle);
 		$.ajax({
 			url: ajaxurl,
 			data,
 			method: 'POST',
-			success(data) {
-				if (!data.success && status) {
-					toggle
-						.parents('tr')
-						.find('td.feedzy-source')
-						.find('.feedzy-error-critical')
-						.remove();
-					toggle
-						.parents('tr')
-						.find('td.feedzy-source')
-						.append($(data.data.msg));
-					toggle.prop('checked', false);
+			success(response) {
+				if (!response.success) {
+					showStatusError(response.data && response.data.msg);
 				}
+			},
+			error(jqXHR) {
+				showStatusError(
+					jqXHR.responseJSON &&
+						jqXHR.responseJSON.data &&
+						jqXHR.responseJSON.data.msg
+				);
 			},
 			complete() {
 				hideSpinner(toggle);
@@ -1113,13 +1120,14 @@
 		});
 
 		// Error logs popup.
-		$('.feedzy-errors-dialog').dialog({
-			modal: true,
-			autoOpen: false,
-			height: 400,
-			width: 500,
-			buttons: [
-				{
+		$('.feedzy-errors-dialog').each(function () {
+			const $dialog = $(this);
+			// the clear-log button mutates the job, so only offer it to users allowed to manage it.
+			const canManageJob = '1' === $dialog.attr('data-can-manage');
+			const buttons = [];
+
+			if (canManageJob) {
+				buttons.push({
 					text: feedzy.i10n.clearLogButton,
 					class: 'button button-primary feedzy-clear-logs',
 					click(event) {
@@ -1129,16 +1137,20 @@
 							'<span class="feedzy-spinner spinner is-active"></span>'
 						).insertAfter(clearButton);
 						clearButton.attr('disabled', true);
-						$.post(
-							ajaxurl,
-							{
-								security: feedzy.ajax.security,
-								id: $(this).attr('data-id'),
-								action: 'feedzy',
-								_action: 'clear_error_logs',
-							},
-							function () {
-								clearButton.next('.feedzy-spinner').remove();
+
+						function resetClearButton() {
+							clearButton.next('.feedzy-spinner').remove();
+							clearButton.attr('disabled', false);
+						}
+
+						$.post(ajaxurl, {
+							security: feedzy.ajax.security,
+							id: $(this).attr('data-id'),
+							action: 'feedzy',
+							_action: 'clear_error_logs',
+						})
+							.done(function () {
+								resetClearButton();
 
 								dialogBox
 									.find('.feedzy-error.feedzy-api-error')
@@ -1147,10 +1159,25 @@
 											feedzy.i10n.removeErrorLogsMsg +
 											'</p></div>'
 									);
-							}
-						);
+							})
+							.fail(function (jqXHR) {
+								resetClearButton();
+
+								const message =
+									jqXHR.responseJSON &&
+									jqXHR.responseJSON.data
+										? jqXHR.responseJSON.data.msg
+										: '';
+								if (message) {
+									// eslint-disable-next-line no-alert
+									window.alert(message);
+								}
+							});
 					},
-				},
+				});
+			}
+
+			buttons.push(
 				{
 					text: window.feedzy.i10n.goToLogsTab,
 					class: 'button button-secondary',
@@ -1164,8 +1191,16 @@
 					click() {
 						$(this).dialog('close');
 					},
-				},
-			],
+				}
+			);
+
+			$dialog.dialog({
+				modal: true,
+				autoOpen: false,
+				height: 400,
+				width: 500,
+				buttons,
+			});
 		});
 
 		$('.feedzy-dialog-open').on('click', function (e) {
@@ -1178,12 +1213,14 @@
 		$('.feedzy-run-now').on('click', function (e) {
 			e.preventDefault();
 			const button = $(this);
+			const originalButtonValue = button.val();
 			button.val(feedzy.i10n.importing);
 
 			const numberRow = button
 				.parents('tr')
 				.find('~ tr.feedzy-import-status-row:first')
 				.find('td tr:first');
+			const originalNumberRowHtml = numberRow.html();
 			numberRow.find('td').hide();
 			numberRow
 				.find('td:first')
@@ -1191,6 +1228,15 @@
 				.attr('colspan', 5)
 				.html(feedzy.i10n.importing)
 				.show();
+
+			function restoreRow(errorMessage) {
+				// put the row back the way it was before this run was attempted.
+				numberRow.html(originalNumberRowHtml);
+				if (errorMessage) {
+					// eslint-disable-next-line no-alert
+					window.alert(errorMessage);
+				}
+			}
 
 			$.ajax({
 				url: ajaxurl,
@@ -1202,13 +1248,24 @@
 					_action: 'run_now',
 				},
 				success(data) {
+					if (!data.success) {
+						restoreRow(data.data && data.data.msg);
+						return;
+					}
 					if (data.data.import_success) {
 						numberRow.find('td:first').addClass('import_success');
 					}
 					numberRow.find('td:first').html(data.data.msg);
 				},
+				error(jqXHR) {
+					restoreRow(
+						jqXHR.responseJSON &&
+							jqXHR.responseJSON.data &&
+							jqXHR.responseJSON.data.msg
+					);
+				},
 				complete() {
-					button.val(feedzy.i10n.run_now);
+					button.val(originalButtonValue);
 				},
 			});
 		});
@@ -1248,6 +1305,16 @@
 				},
 				success() {
 					location.reload();
+				},
+				error(jqXHR) {
+					const message =
+						jqXHR.responseJSON && jqXHR.responseJSON.data
+							? jqXHR.responseJSON.data.msg
+							: '';
+					if (message) {
+						// eslint-disable-next-line no-alert
+						window.alert(message);
+					}
 				},
 				complete() {
 					hideSpinner(element);

--- a/includes/views/js/import-metabox-edit.js
+++ b/includes/views/js/import-metabox-edit.js
@@ -290,9 +290,14 @@
 		};
 
 		function showStatusError(message) {
+			const sourceCell = toggle.parents('tr').find('td.feedzy-source');
+			sourceCell.find('.feedzy-error-critical').remove();
 			if (message) {
-				// eslint-disable-next-line no-alert
-				window.alert(message);
+				if (sourceCell.find('.feedzy-error-critical').length) {
+					sourceCell.find('.feedzy-error-critical').remove();
+				}
+				const errorHtml = `<span class="feedzy-error-critical" style="color: red; display: block; margin-top: 5px;">${message}</span>`;
+				sourceCell.append(errorHtml);
 			}
 			// revert the toggle back to its state prior to this click.
 			toggle.prop('checked', !status);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -936,11 +936,6 @@ parameters:
 			path: includes/admin/feedzy-rss-feeds-import.php
 
 		-
-			message: "#^Parameter \\#1 \\$post of function get_post expects int\\|WP_Post\\|null, string\\|false\\|null given\\.$#"
-			count: 2
-			path: includes/admin/feedzy-rss-feeds-import.php
-
-		-
 			message: "#^Parameter \\#1 \\$post_id of function delete_post_meta expects int, string\\|false\\|null given\\.$#"
 			count: 6
 			path: includes/admin/feedzy-rss-feeds-import.php

--- a/tests/test-import.php
+++ b/tests/test-import.php
@@ -531,6 +531,64 @@ class Test_Feedzy_Import extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Rejects a non-owner Author from running another user's import job, and leaves the
+	 * job and its cron schedule untouched. This endpoint triggers the import itself, so a
+	 * denied request must not run it or disturb its recurring schedule.
+	 */
+	public function test_run_now_ajax_denies_non_owner_author() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$import_id = $this->create_import( $owner_id );
+
+		$cron_args = array( 100, $import_id );
+		Feedzy_Rss_Feeds_Util_Scheduler::schedule_event( time() + HOUR_IN_SECONDS, 'hourly', 'feedzy_cron', $cron_args );
+		$this->assertNotFalse( Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args ) );
+
+		wp_set_current_user( $author_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action' => 'run_now',
+				'id'      => $import_id,
+			)
+		);
+
+		$this->assertFalse( $response['success'] );
+		$this->assertEmpty( get_post_meta( $import_id, 'last_run', true ) );
+		$this->assertNotFalse( Feedzy_Rss_Feeds_Util_Scheduler::is_scheduled( 'feedzy_cron', $cron_args ) );
+	}
+
+	/**
+	 * Rejects a non-owner Author from purging another user's import, leaving its metadata
+	 * and any already-imported posts untouched. This is a destructive path, so the ownership
+	 * check must hold independently of the status and clear-log checks.
+	 */
+	public function test_purge_ajax_denies_non_owner_author() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$import_id = $this->create_import( $owner_id );
+		update_post_meta( $import_id, 'import_post_type', 'post' );
+		update_post_meta( $import_id, 'last_run', time() );
+		update_post_meta( $import_id, 'imported_items_hash', array( 'some-hash' ) );
+
+		$imported_post_id = $this->factory->post->create( array( 'post_author' => $owner_id ) );
+		update_post_meta( $imported_post_id, 'feedzy_job', $import_id );
+
+		wp_set_current_user( $author_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action'            => 'purge',
+				'id'                 => $import_id,
+				'del_imported_posts' => 'true',
+			)
+		);
+
+		$this->assertFalse( $response['success'] );
+		$this->assertNotEmpty( get_post_meta( $import_id, 'last_run', true ) );
+		$this->assertNotEmpty( get_post_meta( $import_id, 'imported_items_hash', true ) );
+		$this->assertInstanceOf( 'WP_Post', get_post( $imported_post_id ) );
+	}
+
+	/**
 	 * Rejects a non-owner Author from clearing another user's import error logs.
 	 */
 	public function test_clear_error_logs_ajax_denies_non_owner_author() {

--- a/tests/test-import.php
+++ b/tests/test-import.php
@@ -469,6 +469,109 @@ class Test_Feedzy_Import extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Rejects a non-owner Author from changing another user's import status via `import_status` AJAX.
+	 */
+	public function test_import_status_ajax_denies_non_owner_author() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$import_id = $this->create_import( $owner_id );
+
+		wp_set_current_user( $author_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action' => 'import_status',
+				'id'      => $import_id,
+				'status'  => 'false',
+			)
+		);
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'publish', get_post_status( $import_id ) );
+	}
+
+	/**
+	 * Allows the owner of an import to change its status via `import_status` AJAX.
+	 */
+	public function test_import_status_ajax_allows_owner() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$import_id = $this->create_import( $owner_id );
+
+		wp_set_current_user( $owner_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action' => 'import_status',
+				'id'      => $import_id,
+				'status'  => 'false',
+			)
+		);
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame( 'draft', get_post_status( $import_id ) );
+	}
+
+	/**
+	 * An administrator can change the status of another user's import.
+	 */
+	public function test_import_status_ajax_allows_admin_on_others_import() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$admin_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$import_id = $this->create_import( $owner_id );
+
+		wp_set_current_user( $admin_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action' => 'import_status',
+				'id'      => $import_id,
+				'status'  => 'false',
+			)
+		);
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame( 'draft', get_post_status( $import_id ) );
+	}
+
+	/**
+	 * Rejects a non-owner Author from clearing another user's import error logs.
+	 */
+	public function test_clear_error_logs_ajax_denies_non_owner_author() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$import_id = $this->create_import( $owner_id );
+		update_post_meta( $import_id, 'import_errors', array( 'Some error' ) );
+
+		wp_set_current_user( $author_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action' => 'clear_error_logs',
+				'id'      => $import_id,
+			)
+		);
+
+		$this->assertFalse( $response['success'] );
+		$this->assertNotEmpty( get_post_meta( $import_id, 'import_errors', true ) );
+	}
+
+	/**
+	 * Owner can clear their own import's error logs.
+	 */
+	public function test_clear_error_logs_ajax_allows_owner() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$import_id = $this->create_import( $owner_id );
+		update_post_meta( $import_id, 'import_errors', array( 'Some error' ) );
+
+		wp_set_current_user( $owner_id );
+		$response = $this->do_feedzy_ajax(
+			array(
+				'_action' => 'clear_error_logs',
+				'id'      => $import_id,
+			)
+		);
+
+		$this->assertEquals( 1, $response['status'] );
+		$this->assertEmpty( get_post_meta( $import_id, 'import_errors', true ) );
+	}
+
+	/**
 	 * Parses the given XML and returns the nodes requested as key value pairs.
 	 */
 	private function parse_xml( $string, $key, $value ) {
@@ -555,6 +658,59 @@ class Test_Feedzy_Import extends WP_UnitTestCase {
 		}
 
 		return $array;
+	}
+
+	/**
+	 * Creates a `feedzy_imports` post owned by the given user.
+	 *
+	 * @param int $owner_id The post_author for the new import.
+	 * @return int The new import post ID.
+	 */
+	private function create_import( $owner_id ) {
+		return $this->factory->post->create(
+			array(
+				'post_type'   => 'feedzy_imports',
+				'post_status' => 'publish',
+				'post_author' => $owner_id,
+			)
+		);
+	}
+
+	/**
+	 * Simulates a `feedzy` AJAX request and returns the decoded response body.
+	 *
+	 * @param array $post The `$_POST` payload; `security` is added automatically.
+	 * @return array The decoded response body.
+	 */
+	private function do_feedzy_ajax( $post ) {
+		$_POST = array_merge(
+			$post,
+			array( 'security' => wp_create_nonce( FEEDZY_BASEFILE ) )
+		);
+		// check_ajax_referer() reads the nonce from $_REQUEST, not $_POST directly.
+		$_REQUEST = array_merge( $_REQUEST, $_POST );
+
+		$ajax_die_handler = function () {
+			return function ( $message ) {
+				throw new WPAjaxDieContinueException( is_scalar( $message ) ? (string) $message : '' );
+			};
+		};
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', $ajax_die_handler );
+
+		ob_start();
+		try {
+			do_action( 'wp_ajax_feedzy' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+		$body = ob_get_clean();
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		remove_filter( 'wp_die_ajax_handler', $ajax_die_handler );
+
+		return json_decode( $body, true );
 	}
 	// @codingStandardsIgnoreEnd WordPress.NamingConventions.ValidVariableName.NotSnakeCase
 }


### PR DESCRIPTION
### Summary
Checked the ownership of the import job before performing any action on it.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/1006