### PR TITLE
chore: exclude js/FeedzyLoop source from the distribution ZIP

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -18,6 +18,7 @@ composer.lock
 package-lock.json
 key.enc
 js/FeedzyBlock
+js/FeedzyLoop/
 js/Conditions/
 js/Onboarding/
 js/ActionPopup/


### PR DESCRIPTION
### Summary

Adds `js/FeedzyLoop/` to `.distignore` so the raw Loop app source is no longer bundled into the distributed plugin ZIP. The other six JS app source directories were already excluded; this one was missed when the Loop app was introduced. Only the compiled `build/loop` output is needed at runtime.

Closes #1295

### Test

Run `npm run dist` and confirm `dist/feedzy-rss-feeds/js` no longer contains `FeedzyLoop` while `build/loop` is still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)