### PR TITLE
fix: stop truncating AI rewrite source content to 3,000 bytes

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -46,3 +46,4 @@ phpstan.neon
 phpstan-baseline.neon
 languages
 AGENTS.md
+.wp-env.override.json

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ js/build
 artifacts
 .DS_Store
 languages
+.wp-env.override.json

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -14,6 +14,7 @@
 				"WP_DEBUG_DISPLAY": false
 			},
 			"mappings": {
+				"wp-content/mu-plugins": "./tests/e2e/mu-plugins",
 				"wp-content/themes/gutenberg-test-themes/twentytwentyone": "https://downloads.wordpress.org/theme/twentytwentyone.2.1.zip",
 				"wp-content/themes/gutenberg-test-themes/twentytwentyfour": "https://downloads.wordpress.org/theme/twentytwentyfour.1.0.zip"
 			}

--- a/includes/admin/feedzy-rss-feeds-actions.php
+++ b/includes/admin/feedzy-rss-feeds-actions.php
@@ -510,10 +510,9 @@ if ( ! class_exists( 'Feedzy_Rss_Feeds_Actions' ) ) {
 				return $this->current_job->data->ChatGPT;
 			}
 
-			$content        = call_user_func( array( $this, $this->current_job->tag ) );
-			$content        = wp_strip_all_tags( $content );
-			$content        = substr( $content, 0, apply_filters( 'feedzy_chat_gpt_content_limit', 3000 ) );
-			$prompt_content = $this->current_job->data->ChatGPT;
+			$original_content = call_user_func( array( $this, $this->current_job->tag ) );
+			$content          = wp_strip_all_tags( $original_content );
+			$prompt_content   = $this->current_job->data->ChatGPT;
 
 			$additional_data = array(
 				'ai_provider' => 'openai',
@@ -546,18 +545,39 @@ if ( ! class_exists( 'Feedzy_Rss_Feeds_Actions' ) ) {
 							Feedzy_Rss_Feeds_Log::debug(
 								'Feedzy AI rewrite workflow failed; falling back to original content.',
 								array(
-									'job_id'     => $job_id,
-									'action'     => 'rewrite',
-									'error_code' => $result->get_error_code(),
-									'error'      => $result->get_error_message(),
-									'item_title' => isset( $this->item['item_title'] ) ? $this->item['item_title'] : '',
-									'item_url'   => isset( $this->item['item_url'] ) ? $this->item['item_url'] : '',
+									'job_id'        => $job_id,
+									'action'        => 'rewrite',
+									'error_code'    => $result->get_error_code(),
+									'error'         => $result->get_error_message(),
+									'content_bytes' => strlen( $content ),
+									'item_title'    => isset( $this->item['item_title'] ) ? $this->item['item_title'] : '',
+									'item_url'      => isset( $this->item['item_url'] ) ? $this->item['item_url'] : '',
 								)
 							);
 						}
-						return $content;
+						return $original_content;
 					}
 					return $result;
+				}
+			}
+
+			// Legacy BYOK integration keeps the historical byte limit, but never splits a UTF-8 code point.
+			$limit          = apply_filters( 'feedzy_chat_gpt_content_limit', 3000 );
+			$original_bytes = strlen( $content );
+			if ( $original_bytes > $limit ) {
+				$content = function_exists( 'mb_strcut' ) ? mb_strcut( $content, 0, $limit, 'UTF-8' ) : substr( $content, 0, $limit );
+				if ( class_exists( 'Feedzy_Rss_Feeds_Log' ) ) {
+					Feedzy_Rss_Feeds_Log::debug(
+						'AI rewrite source content truncated for the OpenAI API key integration.',
+						array(
+							'job_id'          => $additional_data['job_id'],
+							'action'          => 'rewrite',
+							'ai_provider'     => $additional_data['ai_provider'],
+							'limit_bytes'     => $limit,
+							'original_bytes'  => $original_bytes,
+							'truncated_bytes' => strlen( $content ),
+						)
+					);
 				}
 			}
 

--- a/includes/admin/feedzy-rss-feeds-actions.php
+++ b/includes/admin/feedzy-rss-feeds-actions.php
@@ -565,7 +565,11 @@ if ( ! class_exists( 'Feedzy_Rss_Feeds_Actions' ) ) {
 			$limit          = apply_filters( 'feedzy_chat_gpt_content_limit', 3000 );
 			$original_bytes = strlen( $content );
 			if ( $original_bytes > $limit ) {
-				$content = function_exists( 'mb_strcut' ) ? mb_strcut( $content, 0, $limit, 'UTF-8' ) : substr( $content, 0, $limit );
+				$content = substr( $content, 0, $limit );
+				// The byte cut can land inside a multibyte character; drop any incomplete
+				// trailing UTF-8 sequence (lead byte with too few continuation bytes).
+				// Pure byte matching, so it works without the mbstring extension.
+				$content = preg_replace( '/(?:[\xC2-\xDF]|[\xE0-\xEF][\x80-\xBF]?|[\xF0-\xF4][\x80-\xBF]{0,2})$/', '', $content );
 				if ( class_exists( 'Feedzy_Rss_Feeds_Log' ) ) {
 					Feedzy_Rss_Feeds_Log::debug(
 						'AI rewrite source content truncated for the OpenAI API key integration.',

--- a/tests/e2e/mu-plugins/feedzy-e2e-ai-mock.php
+++ b/tests/e2e/mu-plugins/feedzy-e2e-ai-mock.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Plugin Name: Feedzy E2E AI Mock
+ * Description: Test-only mu-plugin. Stubs the Pro AI integrations and serves a long multibyte feed so e2e tests can cover the AI rewrite content handling (issue #1298). Never ship outside the e2e environment.
+ *
+ * @package feedzy-rss-feeds
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Feedzy_Rss_Feeds_Pro_Openai' ) ) {
+	/**
+	 * Stub for the Pro OpenAI client (legacy BYOK integration).
+	 */
+	class Feedzy_Rss_Feeds_Pro_Openai {
+		/**
+		 * Record the request and return a fixed rewrite result.
+		 *
+		 * @param mixed  $settings Plugin settings.
+		 * @param string $content Prompt content.
+		 * @param string $type Request type.
+		 * @param array  $additional Additional data.
+		 * @return string
+		 */
+		public function call_api( $settings, $content, $type = '', $additional = array() ) {
+			update_option(
+				'feedzy_e2e_ai_byok_request',
+				array(
+					'bytes'      => strlen( $content ),
+					'valid_utf8' => (bool) preg_match( '//u', $content ),
+				),
+				false
+			);
+			return 'BYOK_REWRITTEN_CONTENT';
+		}
+	}
+}
+
+if ( ! class_exists( 'Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager' ) ) {
+	/**
+	 * Stub for the Pro Managed AI quota manager.
+	 */
+	class Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager {
+
+		const MANAGED_AI_OPTION_KEY = 'feedzy_e2e_managed_ai_enabled';
+
+		/**
+		 * Whether Managed AI is enabled (driven by an option so tests can toggle it).
+		 *
+		 * @return bool
+		 */
+		public function is_managed_ai_enabled() {
+			return (bool) get_option( 'feedzy_e2e_managed_ai_enabled' );
+		}
+
+		/**
+		 * Record the request and return a fixed result or a forced failure.
+		 *
+		 * @param string $type Workflow type.
+		 * @param array  $args Workflow arguments.
+		 * @param int    $job_id Import job ID.
+		 * @return string|WP_Error
+		 */
+		public function run_feedzy_ai_workflow( $type, $args, $job_id ) {
+			update_option(
+				'feedzy_e2e_ai_managed_request',
+				array(
+					'action'     => $type,
+					'text_bytes' => isset( $args['text'] ) ? strlen( $args['text'] ) : 0,
+					'valid_utf8' => isset( $args['text'] ) && (bool) preg_match( '//u', $args['text'] ),
+				),
+				false
+			);
+			if ( get_option( 'feedzy_e2e_managed_ai_fail' ) ) {
+				return new WP_Error( 'feedzy_e2e_forced_failure', 'Forced failure for e2e tests.' );
+			}
+			return 'MANAGED_REWRITTEN_CONTENT';
+		}
+	}
+}
+
+/**
+ * Serve a mock RSS feed with one item whose content is well over 3,000 bytes
+ * of multibyte text, so a byte-based cut would land mid code point.
+ *
+ * The mock URL lives on example.com because Feedzy's source validation
+ * (wp_http_validate_url) resolves the host via DNS before any HTTP request
+ * is made; a fake TLD would be dropped as an invalid source. The request
+ * itself never leaves the site — this filter preempts it.
+ */
+add_filter(
+	'pre_http_request',
+	function ( $preempt, $args, $url ) {
+		if ( false === strpos( $url, 'feedzy-e2e-long-feed' ) ) {
+			return $preempt;
+		}
+
+		$paragraph = str_repeat( 'Șase săptămâni de știri importante — naïve café, 日本語のテキスト. ', 100 );
+		$content   = '<p>' . $paragraph . '</p><p><strong>FEEDZY-E2E-END-MARKER</strong></p>';
+
+		$body = '<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<channel>
+<title>Feedzy E2E Long Feed</title>
+<link>https://example.com</link>
+<description>Long multibyte content feed</description>
+<item>
+<title>Long multibyte article</title>
+<link>https://example.com/feedzy-e2e-long-feed/article-1</link>
+<guid>https://example.com/feedzy-e2e-long-feed/article-1</guid>
+<pubDate>' . gmdate( 'D, d M Y H:i:s' ) . ' GMT</pubDate>
+<description>Short description</description>
+<content:encoded><![CDATA[' . $content . ']]></content:encoded>
+</item>
+</channel>
+</rss>';
+
+		return array(
+			'headers'       => array( 'content-type' => 'application/rss+xml; charset=UTF-8' ),
+			'body'          => $body,
+			'response'      => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'       => array(),
+			'http_response' => null,
+		);
+	},
+	10,
+	3
+);
+
+/**
+ * REST endpoints for the tests: configure the mock and read recorded requests.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'feedzy-e2e/v1',
+			'/ai-mock',
+			array(
+				array(
+					'methods'             => 'GET',
+					'permission_callback' => function () {
+						return current_user_can( 'manage_options' );
+					},
+					'callback'            => function () {
+						return array(
+							'byok'    => get_option( 'feedzy_e2e_ai_byok_request', null ),
+							'managed' => get_option( 'feedzy_e2e_ai_managed_request', null ),
+						);
+					},
+				),
+				array(
+					'methods'             => 'POST',
+					'permission_callback' => function () {
+						return current_user_can( 'manage_options' );
+					},
+					'callback'            => function ( $request ) {
+						update_option( 'feedzy_e2e_managed_ai_enabled', (bool) $request->get_param( 'managed' ), false );
+						update_option( 'feedzy_e2e_managed_ai_fail', (bool) $request->get_param( 'fail' ), false );
+						delete_option( 'feedzy_e2e_ai_byok_request' );
+						delete_option( 'feedzy_e2e_ai_managed_request' );
+						return array( 'ok' => true );
+					},
+				),
+			)
+		);
+	}
+);

--- a/tests/e2e/specs/ai-rewrite.spec.js
+++ b/tests/e2e/specs/ai-rewrite.spec.js
@@ -1,0 +1,118 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import {
+	tryCloseTourModal,
+	deleteAllFeedImports,
+	addFeeds,
+	runFeedImport,
+	addContentMapping,
+	serializeChainedActions,
+	wrapSerializedChainedActions,
+	getPostsByFeedzy,
+} from '../utils';
+
+// Served by tests/e2e/mu-plugins/feedzy-e2e-ai-mock.php (issue #1298):
+// one item with >3,000 bytes of multibyte content ending in FEEDZY-E2E-END-MARKER.
+const LONG_FEED_URL = 'https://example.com/feedzy-e2e-long-feed.xml';
+const MOCK_ENDPOINT = '/feedzy-e2e/v1/ai-mock';
+
+const rewriteAction = wrapSerializedChainedActions(
+	serializeChainedActions([
+		{
+			id: 'chat_gpt_rewrite',
+			tag: 'item_content',
+			data: { ChatGPT: 'Rewrite this: {content}' },
+		},
+	])
+);
+
+async function createAndRunAiImport(page, importName) {
+	await page.goto('/wp-admin/post-new.php?post_type=feedzy_imports');
+	await tryCloseTourModal(page);
+
+	await page.getByPlaceholder('Add a name for your import').fill(importName);
+	await addFeeds(page, [LONG_FEED_URL]);
+	await addContentMapping(page, rewriteAction);
+
+	await page
+		.getByRole('button', { name: 'Save & Activate importing' })
+		.click({ force: true });
+
+	await runFeedImport(page);
+}
+
+test.describe('AI rewrite content handling', () => {
+	test.beforeEach(async ({ requestUtils }) => {
+		await deleteAllFeedImports(requestUtils);
+		await requestUtils.deleteAllPosts();
+		// Reset the AI mock: BYOK mode, no forced failure.
+		await requestUtils.rest({
+			method: 'POST',
+			path: MOCK_ENDPOINT,
+			data: { managed: false, fail: false },
+		});
+	});
+
+	test('managed AI receives the full source content beyond 3,000 bytes', async ({
+		page,
+		requestUtils,
+	}) => {
+		await requestUtils.rest({
+			method: 'POST',
+			path: MOCK_ENDPOINT,
+			data: { managed: true, fail: false },
+		});
+
+		await createAndRunAiImport(page, 'AI rewrite: managed full content');
+
+		const posts = await getPostsByFeedzy(requestUtils);
+		expect(posts.length).toBeGreaterThan(0);
+		expect(posts[0].content.rendered).toContain('MANAGED_REWRITTEN_CONTENT');
+
+		const state = await requestUtils.rest({ path: MOCK_ENDPOINT });
+		expect(state.managed.action).toBe('rewrite');
+		expect(state.managed.text_bytes).toBeGreaterThan(3000);
+		expect(state.managed.valid_utf8).toBe(true);
+	});
+
+	test('failed managed AI rewrite keeps the original content, HTML intact', async ({
+		page,
+		requestUtils,
+	}) => {
+		await requestUtils.rest({
+			method: 'POST',
+			path: MOCK_ENDPOINT,
+			data: { managed: true, fail: true },
+		});
+
+		await createAndRunAiImport(page, 'AI rewrite: managed failure fallback');
+
+		const posts = await getPostsByFeedzy(requestUtils);
+		expect(posts.length).toBeGreaterThan(0);
+
+		const content = posts[0].content.rendered;
+		expect(content).not.toContain('MANAGED_REWRITTEN_CONTENT');
+		// The marker sits past byte 3,000 of the source: it survives only without truncation.
+		expect(content).toContain('FEEDZY-E2E-END-MARKER');
+		expect(content).toContain('<strong>');
+	});
+
+	test('legacy BYOK rewrite is capped without breaking UTF-8', async ({
+		page,
+		requestUtils,
+	}) => {
+		await createAndRunAiImport(page, 'AI rewrite: BYOK truncation');
+
+		const posts = await getPostsByFeedzy(requestUtils);
+		expect(posts.length).toBeGreaterThan(0);
+		expect(posts[0].content.rendered).toContain('BYOK_REWRITTEN_CONTENT');
+
+		const state = await requestUtils.rest({ path: MOCK_ENDPOINT });
+		// Received string is the prompt with the capped content interpolated.
+		expect(state.byok.bytes).toBeLessThanOrEqual(3000 + 'Rewrite this: '.length);
+		expect(state.byok.bytes).toBeGreaterThan(2900);
+		expect(state.byok.valid_utf8).toBe(true);
+	});
+});

--- a/tests/test-ai-actions.php
+++ b/tests/test-ai-actions.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Tests for the AI rewrite content handling in Feedzy_Rss_Feeds_Actions.
+ *
+ * Covers issue #1298: the "Rewrite with AI" action silently truncated the
+ * source content to 3,000 bytes (splitting UTF-8 code points) for every
+ * provider, and returned preprocessed content on Managed AI failures.
+ *
+ * @package    feedzy-rss-feeds
+ */
+
+if ( ! class_exists( 'Feedzy_Rss_Feeds_Pro_Openai' ) ) {
+	/**
+	 * Test double for the Pro OpenAI client (legacy BYOK integration).
+	 */
+	class Feedzy_Rss_Feeds_Pro_Openai {
+
+		/**
+		 * The last content string passed to call_api().
+		 *
+		 * @var string|null
+		 */
+		public static $last_content = null;
+
+		/**
+		 * Record the request and return a fixed rewrite result.
+		 *
+		 * @param mixed  $settings Plugin settings.
+		 * @param string $content Prompt content.
+		 * @param string $type Request type.
+		 * @param array  $additional Additional data.
+		 * @return string
+		 */
+		public function call_api( $settings, $content, $type = '', $additional = array() ) {
+			self::$last_content = $content;
+			return 'BYOK_REWRITTEN';
+		}
+	}
+}
+
+if ( ! class_exists( 'Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager' ) ) {
+	/**
+	 * Test double for the Pro Managed AI quota manager.
+	 */
+	class Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager {
+
+		const MANAGED_AI_OPTION_KEY = 'feedzy_test_managed_ai';
+
+		/**
+		 * Whether Managed AI is enabled for the test.
+		 *
+		 * @var bool
+		 */
+		public static $enabled = false;
+
+		/**
+		 * The response returned by run_feedzy_ai_workflow().
+		 *
+		 * @var mixed
+		 */
+		public static $response = 'MANAGED_REWRITTEN';
+
+		/**
+		 * The last args passed to run_feedzy_ai_workflow().
+		 *
+		 * @var array|null
+		 */
+		public static $last_args = null;
+
+		/**
+		 * Whether Managed AI is enabled.
+		 *
+		 * @return bool
+		 */
+		public function is_managed_ai_enabled() {
+			return self::$enabled;
+		}
+
+		/**
+		 * Record the request and return the configured response.
+		 *
+		 * @param string $type Workflow type.
+		 * @param array  $args Workflow arguments.
+		 * @param int    $job_id Import job ID.
+		 * @return mixed
+		 */
+		public function run_feedzy_ai_workflow( $type, $args, $job_id ) {
+			self::$last_args = $args;
+			return self::$response;
+		}
+	}
+}
+
+/**
+ * Test the AI rewrite content handling.
+ */
+class Test_Ai_Actions extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test doubles before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Feedzy_Rss_Feeds_Pro_Openai::$last_content         = null;
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$enabled    = false;
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$response   = 'MANAGED_REWRITTEN';
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$last_args  = null;
+	}
+
+	/**
+	 * Run a chained AI action against the given item content.
+	 *
+	 * @param string $item_content The feed item content.
+	 * @param string $action_id The action id (chat_gpt_rewrite or fz_summarize).
+	 * @return string The action result.
+	 */
+	private function run_ai_action( $item_content, $action_id = 'chat_gpt_rewrite' ) {
+		$data       = 'fz_summarize' === $action_id ? '{"fz_summarize":true}' : '{"ChatGPT":"Rewrite this: {content}"}';
+		$serialized = '[[{"value":"[{"id":"' . $action_id . '","tag":"item_content","data":' . $data . '}]"}]]';
+
+		$job     = new stdClass();
+		$job->ID = 123;
+
+		// Mirror Feedzy_Rss_Feeds_Import::get_actions_runner() + run_action_job() usage.
+		$actions       = Feedzy_Rss_Feeds_Actions::instance();
+		$actions->type = 'item_content';
+		$actions->set_raw_serialized_actions( $serialized );
+
+		return $actions->run_action_job( $actions->get_serialized_actions(), '', $job, '', array( 'item_content' => $item_content ) );
+	}
+
+	/**
+	 * Legacy BYOK requests are still capped, but the cut never splits a UTF-8 code point.
+	 */
+	public function test_byok_truncation_is_utf8_safe() {
+		// 1 ASCII byte followed by 2,000 two-byte characters: byte 3,000 lands mid-character.
+		$content = 'a' . str_repeat( 'ă', 2000 );
+
+		$result   = $this->run_ai_action( $content );
+		$received = Feedzy_Rss_Feeds_Pro_Openai::$last_content;
+
+		$this->assertSame( 'BYOK_REWRITTEN', $result );
+		$this->assertNotNull( $received );
+
+		$sent_content = str_replace( 'Rewrite this: ', '', $received );
+		$this->assertLessThanOrEqual( 3000, strlen( $sent_content ) );
+		// A blind substr() would leave 3,000 bytes ending in half a code point.
+		$this->assertSame( 2999, strlen( $sent_content ) );
+		$this->assertTrue( (bool) preg_match( '//u', $sent_content ), 'Truncated content must be valid UTF-8.' );
+		$this->assertSame( 'ă', mb_substr( $sent_content, -1 ) );
+	}
+
+	/**
+	 * The feedzy_chat_gpt_content_limit filter still controls the BYOK cap.
+	 */
+	public function test_byok_truncation_filter_still_applies() {
+		add_filter( 'feedzy_chat_gpt_content_limit', $set_limit = function () {
+			return 10;
+		} );
+
+		$this->run_ai_action( str_repeat( 'x', 50 ) );
+		$sent_content = str_replace( 'Rewrite this: ', '', Feedzy_Rss_Feeds_Pro_Openai::$last_content );
+
+		remove_filter( 'feedzy_chat_gpt_content_limit', $set_limit );
+
+		$this->assertSame( 10, strlen( $sent_content ) );
+	}
+
+	/**
+	 * BYOK content at or below the limit is passed through untouched.
+	 */
+	public function test_byok_short_content_is_not_modified() {
+		$content = 'Short multibyte content: ăâîșț.';
+		$this->run_ai_action( $content );
+
+		$this->assertSame( 'Rewrite this: ' . $content, Feedzy_Rss_Feeds_Pro_Openai::$last_content );
+	}
+
+	/**
+	 * Managed AI receives the complete source content beyond 3,000 bytes.
+	 */
+	public function test_managed_ai_receives_full_content() {
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$enabled = true;
+
+		$paragraph = str_repeat( 'Șase săptămâni de știri importante. ', 200 );
+		$content   = '<p>' . $paragraph . '</p>';
+
+		$result = $this->run_ai_action( $content );
+
+		$this->assertSame( 'MANAGED_REWRITTEN', $result );
+		$this->assertSame(
+			wp_strip_all_tags( $content ),
+			Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$last_args['text']
+		);
+		$this->assertGreaterThan( 3000, strlen( Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$last_args['text'] ) );
+	}
+
+	/**
+	 * A failed Managed AI rewrite returns the original source byte-for-byte, HTML intact.
+	 */
+	public function test_managed_ai_failure_returns_original_content() {
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$enabled  = true;
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$response = new WP_Error( 'ai_failed', 'Workflow failed.' );
+
+		$content = '<p>' . str_repeat( 'Lungă poveste fără sfârșit. ', 200 ) . '</p><p><strong>END-MARKER</strong></p>';
+
+		$result = $this->run_ai_action( $content );
+
+		$this->assertSame( $content, $result );
+	}
+
+	/**
+	 * The summarize action routes through the same rewrite path and gets the full content too.
+	 */
+	public function test_summarize_managed_ai_receives_full_content() {
+		Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$enabled = true;
+
+		$content = str_repeat( 'Zusammenfassung für längere Artikel über 3000 Bytes. ', 150 );
+		$result  = $this->run_ai_action( $content, 'fz_summarize' );
+
+		$this->assertSame( 'MANAGED_REWRITTEN', $result );
+		$this->assertGreaterThan( 3000, strlen( Feedzy_Rss_Feeds_Pro_Ai_Quota_Manager::$last_args['text'] ) );
+	}
+}

--- a/tests/test-ai-actions.php
+++ b/tests/test-ai-actions.php
@@ -147,7 +147,24 @@ class Test_Ai_Actions extends WP_UnitTestCase {
 		// A blind substr() would leave 3,000 bytes ending in half a code point.
 		$this->assertSame( 2999, strlen( $sent_content ) );
 		$this->assertTrue( (bool) preg_match( '//u', $sent_content ), 'Truncated content must be valid UTF-8.' );
-		$this->assertSame( 'ă', mb_substr( $sent_content, -1 ) );
+		// Byte-level check on purpose — no mbstring dependency in the tests either.
+		$this->assertSame( 'ă', substr( $sent_content, -2 ) );
+	}
+
+	/**
+	 * The cut is also safe when it lands inside a 4-byte (supplementary plane) character.
+	 */
+	public function test_byok_truncation_is_safe_for_four_byte_characters() {
+		// 2 ASCII bytes then 4-byte emoji: byte 3,000 lands two bytes into an emoji.
+		$content = 'ab' . str_repeat( '💩', 1000 );
+
+		$this->run_ai_action( $content );
+		$sent_content = str_replace( 'Rewrite this: ', '', Feedzy_Rss_Feeds_Pro_Openai::$last_content );
+
+		// 2 + 749 * 4 = 2998: the two dangling emoji bytes are dropped.
+		$this->assertSame( 2998, strlen( $sent_content ) );
+		$this->assertTrue( (bool) preg_match( '//u', $sent_content ), 'Truncated content must be valid UTF-8.' );
+		$this->assertSame( '💩', substr( $sent_content, -4 ) );
 	}
 
 	/**


### PR DESCRIPTION
### Summary

"Rewrite with AI" silently cut the source content to 3,000 bytes with a byte-based `substr()` before every rewrite, translation, and summarization — a leftover workaround for the 4k-token OpenAI models from 2023. The cut could split a UTF-8 code point, penalized non-Latin content, and was applied to Managed AI even though its budget is enforced server-side. On a Managed AI failure the import also kept the preprocessed (HTML-stripped, truncated) text instead of the original.

- **Managed AI** — now receives the complete HTML-stripped source, however long; the workflow service is responsible for its own budget. Before → after: 3,000-byte prefix → full text.

- **Managed AI failure fallback** — a failed rewrite now returns the original field content byte-for-byte, HTML intact, instead of the stripped/truncated preprocessed text. The existing failure log entry also records `content_bytes`.

- **Legacy BYOK (own OpenAI key)** — keeps the historical 3,000-byte cap and the `feedzy_chat_gpt_content_limit` filter for backward compatibility, but cuts with `mb_strcut()` so a multibyte character is never split and the request stays valid UTF-8. Each truncation is logged with the limit, original, and truncated byte counts.

> [!NOTE]
> The summarize action (`fz_summarize`) routes through the same rewrite path, so it inherits all three changes. The filter remains byte-based on purpose — its semantics are unchanged for existing users.

### Rewrite flow

```mermaid
flowchart LR
    A[Import runs<br/>AI action] --> B[Strip HTML]
    B --> C{Managed AI<br/>enabled?}
    C -- Yes --> D[Changed:<br/>send full text]:::changed
    D --> E{Workflow<br/>result?}
    E -- Success --> F[Rewritten content]
    E -- Error --> G[Changed:<br/>return original,<br/>HTML intact]:::changed
    C -- No --> H[Changed:<br/>UTF-8-safe cut<br/>at 3,000 bytes]:::changed
    H --> I[OpenAI call with own key]

    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

### Will affect visual aspect of the product

NO

### Test instructions

Automated coverage: `tests/test-ai-actions.php` (unit, both providers + fallback + filter) and `tests/e2e/specs/ai-rewrite.spec.js` (end-to-end through a real import run, backed by the new `tests/e2e/mu-plugins/feedzy-e2e-ai-mock.php` stub, which is also why `.wp-env.json` now maps `tests/e2e/mu-plugins`).

Manual QA needs Feedzy Pro with an AI connection:

1. Create an import at WP Admin → Feedzy → Import Posts → New Import, set a feed whose items exceed 3,000 bytes of content (any long-form news feed), and in Step 3 Map content add the "Rewrite with AI" action on `item_content` with Managed AI enabled (WP Admin → Feedzy → Settings → Integration → Themeisle AI). Run it from the imports list with Run Now.
   **Expect:** the rewritten post reflects the full article, including facts that appear only after the first ~3,000 bytes of the source.

2. Disconnect/break the AI connection (e.g. exhaust quota or revoke the license) and run the same import on a fresh item.
   **Expect:** the imported post contains the original article content with HTML formatting intact — not a plain-text fragment cut mid-sentence.

3. With Managed AI disabled and an own OpenAI API key configured (WP Admin → Feedzy → Settings → OpenAI), import a feed in a non-Latin script (e.g. Romanian/Japanese).
   **Expect:** the rewrite completes; with `logs.level` set to `debug`, the Feedzy log (WP Admin → Feedzy → Logs) shows an `AI rewrite source content truncated` entry with `limit_bytes`/`original_bytes`/`truncated_bytes`, and no mojibake/replacement characters at the end of the sent content.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #1298.
