### PR TITLE
fix: lazy feed loader remains on Loading... after request failure

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -472,6 +472,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 			// Add nonce based on feed url.
 			$attributes .= 'data-nonce="' . esc_attr( wp_create_nonce( $feed_url ) ) . '"';
+			$attributes .= 'data-error_msg="' . esc_attr( apply_filters( 'feedzy_lazyload_error_msg', __( 'The feed could not be loaded.', 'feedzy-rss-feeds' ), $feed_url ) ) . '"';
 
 			$class = array_filter( apply_filters( 'feedzy_add_classes_block', array( $sc['classname'], 'feedzy-' . md5( is_array( $feed_url ) ? implode( ',', $feed_url ) : $feed_url ) ), $sc, null, $feed_url ) );
 			$html  = "<div class='feedzy-lazy' $attributes>";
@@ -486,7 +487,6 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 					'url'        => get_rest_url( null, 'feedzy/v' . FEEDZY_REST_VERSION . '/lazy/' ),
 					'rest_nonce' => wp_create_nonce( 'wp_rest' ),
 					'nonce'      => wp_create_nonce( 'feedzy' ),
-					'error'      => apply_filters( 'feedzy_lazyload_error_msg', __( 'The feed could not be loaded.', 'feedzy-rss-feeds' ), $feed_url ),
 				)
 			);
 			return $html;

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -486,6 +486,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 					'url'        => get_rest_url( null, 'feedzy/v' . FEEDZY_REST_VERSION . '/lazy/' ),
 					'rest_nonce' => wp_create_nonce( 'wp_rest' ),
 					'nonce'      => wp_create_nonce( 'feedzy' ),
+					'error'      => apply_filters( 'feedzy_lazyload_error_msg', __( 'The feed could not be loaded.', 'feedzy-rss-feeds' ), $feed_url ),
 				)
 			);
 			return $html;

--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -472,7 +472,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 			// Add nonce based on feed url.
 			$attributes .= 'data-nonce="' . esc_attr( wp_create_nonce( $feed_url ) ) . '"';
-			$attributes .= 'data-error_msg="' . esc_attr( apply_filters( 'feedzy_lazyload_error_msg', __( 'The feed could not be loaded.', 'feedzy-rss-feeds' ), $feed_url ) ) . '"';
+			$attributes .= 'data-error_msg="' . esc_attr( apply_filters( 'feedzy_lazyload_error_msg', __( 'An error occurred while fetching the feed.', 'feedzy-rss-feeds' ), $feed_url ) ) . '"';
 
 			$class = array_filter( apply_filters( 'feedzy_add_classes_block', array( $sc['classname'], 'feedzy-' . md5( is_array( $feed_url ) ? implode( ',', $feed_url ) : $feed_url ) ), $sc, null, $feed_url ) );
 			$html  = "<div class='feedzy-lazy' $attributes>";

--- a/js/feedzy-lazy.js
+++ b/js/feedzy-lazy.js
@@ -45,11 +45,11 @@
                     } else if('string' === typeof data && data.length){
                         $feedzy_block.empty().append(data);
                     } else {
-                        $feedzy_block.empty().append(feedzy.error);
+                        $feedzy_block.empty().append($attributes.error_msg);
                     }
                 },
                 error: function(){
-                    $feedzy_block.empty().append(feedzy.error);
+                    $feedzy_block.empty().append($attributes.error_msg);
                 },
                 complete: function(){
                     $feedzy_block.removeClass('loading');

--- a/js/feedzy-lazy.js
+++ b/js/feedzy-lazy.js
@@ -38,11 +38,18 @@
                     xhr.setRequestHeader('X-WP-Nonce', feedzy.rest_nonce);
                 },
                 success: function(data){
-                    if(data.success){
+                    if(data && data.success && data.data && data.data.content){
                         $feedzy_block.empty().append(data.data.content);
-                    } else {
+                    } else if(data && data.data && data.data.message){
                         $feedzy_block.empty().append(data.data.message);
+                    } else if('string' === typeof data && data.length){
+                        $feedzy_block.empty().append(data);
+                    } else {
+                        $feedzy_block.empty().append(feedzy.error);
                     }
+                },
+                error: function(){
+                    $feedzy_block.empty().append(feedzy.error);
                 },
                 complete: function(){
                     $feedzy_block.removeClass('loading');

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -89,6 +89,191 @@ test.describe('Feed Import', () => {
 		).resolves.toBeGreaterThan(0);
 	});
 
+	test('lazy loading feed exits loading state when the request fails', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		// Distinct attributes so the lazy-load transient cache is cold and the
+		// initial render shows the loading indicator.
+		const lazyShortcode =
+			"[feedzy-rss feeds='https://s3.amazonaws.com/verti-utils/sample-feed.xml' max='3' feed_title='yes' refresh='1_hours' template='style1' lazy='yes']";
+
+		await admin.createNewPost();
+
+		// Insert a shortcode block.
+		await editor.insertBlock({ name: 'core/shortcode' });
+		await editor.canvas
+			.getByPlaceholder('Write shortcode here…')
+			.fill(lazyShortcode);
+
+		const postId = await editor.publishPost();
+
+		// Force the lazy REST request to fail at the network layer.
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.abort('failed')
+		);
+
+		await page.goto(`/?p=${postId}`);
+
+		const lazyContainer = page.locator('.feedzy-lazy');
+		await expect(lazyContainer).toBeVisible();
+		await expect(lazyContainer).toContainText('Loading');
+
+		// Wait until the lazy request has actually been attempted (and failed).
+		await page.waitForRequest(/feedzy\/v\d+\/lazy/);
+
+		// The container must exit the loading state and show feed content or
+		// an error message instead of an indefinite loading indicator.
+		await expect(lazyContainer).not.toContainText('Loading', {
+			timeout: 10000,
+		});
+	});
+
+	test('lazy loading feed exits loading state on a malformed response', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		// The REST callback can return a raw string (e.g. a fetch error)
+		// instead of the expected { success, data } envelope.
+		const lazyShortcode =
+			"[feedzy-rss feeds='https://s3.amazonaws.com/verti-utils/sample-feed.xml' max='4' feed_title='yes' refresh='1_hours' template='style1' lazy='yes']";
+
+		await admin.createNewPost();
+
+		// Insert a shortcode block.
+		await editor.insertBlock({ name: 'core/shortcode' });
+		await editor.canvas
+			.getByPlaceholder('Write shortcode here…')
+			.fill(lazyShortcode);
+
+		const postId = await editor.publishPost();
+
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify('Feed fetch failed.'),
+			})
+		);
+
+		await page.goto(`/?p=${postId}`);
+
+		const lazyContainer = page.locator('.feedzy-lazy');
+		await expect(lazyContainer).toContainText('Loading');
+		await page.waitForRequest(/feedzy\/v\d+\/lazy/);
+
+		// The raw string should be surfaced instead of a stuck loader.
+		await expect(lazyContainer).toContainText('Feed fetch failed.', {
+			timeout: 10000,
+		});
+	});
+
+	// Publish a post with a lazy shortcode. A unique max value gives a cold
+	// lazy-load cache so the initial render shows the loading indicator.
+	async function publishLazyPost(admin, editor, max) {
+		await admin.createNewPost();
+		await editor.insertBlock({ name: 'core/shortcode' });
+		await editor.canvas
+			.getByPlaceholder('Write shortcode here…')
+			.fill(
+				`[feedzy-rss feeds='https://s3.amazonaws.com/verti-utils/sample-feed.xml' max='${max}' feed_title='yes' refresh='1_hours' template='style1' lazy='yes']`
+			);
+		return editor.publishPost();
+	}
+
+	async function expectLazyResult(page, postId, expectedText) {
+		await page.goto(`/?p=${postId}`);
+		const lazyContainer = page.locator('.feedzy-lazy');
+		await expect(lazyContainer).toContainText('Loading');
+		await page.waitForRequest(/feedzy\/v\d+\/lazy/);
+		await expect(lazyContainer).toContainText(expectedText, {
+			timeout: 10000,
+		});
+	}
+
+	test('lazy loading feed shows an error on a server error response', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		const postId = await publishLazyPost(admin, editor, 5);
+
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.fulfill({
+				status: 500,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					code: 'internal_server_error',
+					message: 'Internal server error',
+					data: { status: 500 },
+				}),
+			})
+		);
+
+		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+	});
+
+	test('lazy loading feed shows an error when the JSON response is corrupted', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		const postId = await publishLazyPost(admin, editor, 6);
+
+		// A PHP notice printed before the JSON payload breaks parsing.
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: '<b>Notice</b>: Undefined variable {"success":true,"data":{"content":"x"}}',
+			})
+		);
+
+		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+	});
+
+	test('lazy loading feed shows the server message on a json_error response', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		const postId = await publishLazyPost(admin, editor, 7);
+
+		// The shape produced by wp_send_json_error(), e.g. a failed nonce.
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: false,
+					data: { message: 'Security check failed.' },
+				}),
+			})
+		);
+
+		await expectLazyResult(page, postId, 'Security check failed.');
+	});
+
+	test('lazy loading feed shows an error when a successful response has no content', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		const postId = await publishLazyPost(admin, editor, 8);
+
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ success: true, data: {} }),
+			})
+		);
+
+		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+	});
+
 	test('import multiple feeds with shortcode', async ({
 		editor,
 		page,

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -89,87 +89,6 @@ test.describe('Feed Import', () => {
 		).resolves.toBeGreaterThan(0);
 	});
 
-	test('lazy loading feed exits loading state when the request fails', async ({
-		editor,
-		page,
-		admin,
-	}) => {
-		// Distinct attributes so the lazy-load transient cache is cold and the
-		// initial render shows the loading indicator.
-		const lazyShortcode =
-			"[feedzy-rss feeds='https://s3.amazonaws.com/verti-utils/sample-feed.xml' max='3' feed_title='yes' refresh='1_hours' template='style1' lazy='yes']";
-
-		await admin.createNewPost();
-
-		// Insert a shortcode block.
-		await editor.insertBlock({ name: 'core/shortcode' });
-		await editor.canvas
-			.getByPlaceholder('Write shortcode here…')
-			.fill(lazyShortcode);
-
-		const postId = await editor.publishPost();
-
-		// Force the lazy REST request to fail at the network layer.
-		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
-			route.abort('failed')
-		);
-
-		await page.goto(`/?p=${postId}`);
-
-		const lazyContainer = page.locator('.feedzy-lazy');
-		await expect(lazyContainer).toBeVisible();
-		await expect(lazyContainer).toContainText('Loading');
-
-		// Wait until the lazy request has actually been attempted (and failed).
-		await page.waitForRequest(/feedzy\/v\d+\/lazy/);
-
-		// The container must exit the loading state and show feed content or
-		// an error message instead of an indefinite loading indicator.
-		await expect(lazyContainer).not.toContainText('Loading', {
-			timeout: 10000,
-		});
-	});
-
-	test('lazy loading feed exits loading state on a malformed response', async ({
-		editor,
-		page,
-		admin,
-	}) => {
-		// The REST callback can return a raw string (e.g. a fetch error)
-		// instead of the expected { success, data } envelope.
-		const lazyShortcode =
-			"[feedzy-rss feeds='https://s3.amazonaws.com/verti-utils/sample-feed.xml' max='4' feed_title='yes' refresh='1_hours' template='style1' lazy='yes']";
-
-		await admin.createNewPost();
-
-		// Insert a shortcode block.
-		await editor.insertBlock({ name: 'core/shortcode' });
-		await editor.canvas
-			.getByPlaceholder('Write shortcode here…')
-			.fill(lazyShortcode);
-
-		const postId = await editor.publishPost();
-
-		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
-			route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify('Feed fetch failed.'),
-			})
-		);
-
-		await page.goto(`/?p=${postId}`);
-
-		const lazyContainer = page.locator('.feedzy-lazy');
-		await expect(lazyContainer).toContainText('Loading');
-		await page.waitForRequest(/feedzy\/v\d+\/lazy/);
-
-		// The raw string should be surfaced instead of a stuck loader.
-		await expect(lazyContainer).toContainText('Feed fetch failed.', {
-			timeout: 10000,
-		});
-	});
-
 	// Publish a post with a lazy shortcode. A unique max value gives a cold
 	// lazy-load cache so the initial render shows the loading indicator.
 	async function publishLazyPost(admin, editor, max) {
@@ -183,15 +102,52 @@ test.describe('Feed Import', () => {
 		return editor.publishPost();
 	}
 
+	// The request promise is created before navigation so a request fired
+	// during a slow page load cannot slip past the listener.
 	async function expectLazyResult(page, postId, expectedText) {
+		const lazyRequest = page.waitForRequest(/feedzy\/v\d+\/lazy/);
 		await page.goto(`/?p=${postId}`);
-		const lazyContainer = page.locator('.feedzy-lazy');
-		await expect(lazyContainer).toContainText('Loading');
-		await page.waitForRequest(/feedzy\/v\d+\/lazy/);
-		await expect(lazyContainer).toContainText(expectedText, {
-			timeout: 10000,
-		});
+		await lazyRequest;
+		await expect(page.locator('.feedzy-lazy')).toContainText(
+			expectedText,
+			{ timeout: 10000 }
+		);
 	}
+
+	test('lazy loading feed exits loading state when the request fails', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		const postId = await publishLazyPost(admin, editor, 3);
+
+		// Force the lazy REST request to fail at the network layer.
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.abort('failed')
+		);
+
+		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+	});
+
+	test('lazy loading feed exits loading state on a malformed response', async ({
+		editor,
+		page,
+		admin,
+	}) => {
+		const postId = await publishLazyPost(admin, editor, 4);
+
+		// The REST callback can return a raw string (e.g. a fetch error)
+		// instead of the expected { success, data } envelope.
+		await page.route(/feedzy\/v\d+\/lazy/, (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify('Feed fetch failed.'),
+			})
+		);
+
+		await expectLazyResult(page, postId, 'Feed fetch failed.');
+	});
 
 	test('lazy loading feed shows an error on a server error response', async ({
 		editor,

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -126,7 +126,7 @@ test.describe('Feed Import', () => {
 			route.abort('failed')
 		);
 
-		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+		await expectLazyResult(page, postId, 'An error occurred while fetching the feed.');
 	});
 
 	test('lazy loading feed exits loading state on a malformed response', async ({
@@ -168,7 +168,7 @@ test.describe('Feed Import', () => {
 			})
 		);
 
-		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+		await expectLazyResult(page, postId, 'An error occurred while fetching the feed.');
 	});
 
 	test('lazy loading feed shows an error when the JSON response is corrupted', async ({
@@ -187,7 +187,7 @@ test.describe('Feed Import', () => {
 			})
 		);
 
-		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+		await expectLazyResult(page, postId, 'An error occurred while fetching the feed.');
 	});
 
 	test('lazy loading feed shows the server message on a json_error response', async ({
@@ -227,7 +227,7 @@ test.describe('Feed Import', () => {
 			})
 		);
 
-		await expectLazyResult(page, postId, 'The feed could not be loaded.');
+		await expectLazyResult(page, postId, 'An error occurred while fetching the feed.');
 	});
 
 	test('import multiple feeds with shortcode', async ({


### PR DESCRIPTION
A `[feedzy-rss]` shortcode with `lazy='yes'` left visitors on an indefinite "Loading..." whenever the request fetching the feed content failed — a dropped connection, an HTTP error, or a response the handler couldn't parse. The lazy loader now always exits the loading state: it renders the feed on success and shows an error message on any failure. Reported in [issue #1299](https://github.com/Codeinwp/feedzy-rss-feeds/issues/1299), originally from HelpScout conversation 3402495948.

## What changed

- **Lazy loader (`js/feedzy-lazy.js`)** — failed requests now replace "Loading..." with a localized "The feed could not be loaded." message. Before → after: stuck loader forever → error message about one second after the failure.

- **Response handling** — HTTP 200 responses without usable content no longer strand or blank the container: `wp_send_json_error()` envelopes show the server's message, raw string returns from the REST callback are rendered as-is, and a `success:true` payload missing `data.content` falls back to the error message.

- **Error message (`feedzy-rss-feeds-admin-abstract.php`)** — the message is translatable and filterable via a new `feedzy_lazyload_error_msg` filter, mirroring the existing `feedzy_lazyload_loading_msg` filter for the loading text.

## Lazy load flow

```mermaid
flowchart LR
    A[Page renders<br/>lazy shortcode] --> B{Cached<br/>content?}
    B -- Yes --> C[Feed shown<br/>immediately]
    B -- No --> D["Loading... +<br/>request to<br/>/feedzy/v1/lazy"]
    D --> E{Changed:<br/>response has<br/>rendered content?}:::changed
    E -- Yes --> F[Feed items shown]
    E -- "No, server sent<br/>a message" --> G[New:<br/>show server message]:::added
    E -- "No, request failed<br/>or malformed" --> H[New:<br/>show error message]:::added

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## QA

1. In WP Admin → Posts → Add New Post, insert a **Shortcode** block (the generic core block, not the Feedzy block — the Feedzy block intentionally skips lazy loading) containing:
   ```
   [feedzy-rss feeds='https://s3.amazonaws.com/verti-utils/sample-feed.xml' max='3' lazy='yes']
   ```
   Publish and view the post.
   **Expect:** "Loading..." appears briefly, then the feed items render.
2. Edit the post and change `max` to a value not used before (each successful load caches the rendered feed per attribute set, so a fresh value forces the loading state). Update the post. On the post's frontend page, open DevTools → Network, filter by `lazy`, reload once, right-click the **`lazy/` fetch request** (not the `feedzy-lazy.js` script) → **Block request URL**. Change `max` again, update, and reload the post.
   **Expect:** "Loading..." switches to "The feed could not be loaded." about one second after the blocked request appears — previously it stayed on "Loading..." indefinitely.
3. Remove the blocking pattern and reload the post with one more fresh `max` value.
   **Expect:** the feed loads normally again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
