### PR TITLE
Handled missing Tagify method

### DIFF
--- a/js/ActionPopup/index.js
+++ b/js/ActionPopup/index.js
@@ -17,6 +17,21 @@ import {
 
 import { Icon, dragHandle, close, plus, trash } from '@wordpress/icons';
 
+/**
+ * Drop the data Tagify keeps in the browser storage for the given instance.
+ *
+ * @param {Object} tagify The Tagify instance.
+ */
+const clearTagifyPersistedData = (tagify) => {
+	if ('function' === typeof tagify?.clearPersistedData) {
+		tagify.clearPersistedData();
+		return;
+	}
+	if ('function' === typeof tagify?.setPersistedData) {
+		tagify.setPersistedData([], 'value');
+	}
+};
+
 const ActionModal = () => {
 	// useRef
 	const userRef = useRef(null);
@@ -236,7 +251,7 @@ const ActionModal = () => {
 		if ('import_post_featured_img' === fieldName) {
 			inputField.removeAllTags();
 			inputField.addEmptyTag();
-			inputField.clearPersistedData();
+			clearTagifyPersistedData(inputField);
 		}
 		if (null === editModeTag || 'import_post_featured_img' === fieldName) {
 			const tagElm = inputField.createTagElem({ value: _action });

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -305,6 +305,59 @@ test.describe('Feed Import', () => {
 		).resolves.toBeGreaterThan(0); // We should have some imported images.
 	});
 
+	test('save featured image action when Tagify has no persistence API', async ({
+		page,
+	}) => {
+		const featuredImgInput =
+			'input[name="feedzy_meta_data[import_post_featured_img]"]';
+		const pageErrors = [];
+		page.on('pageerror', (error) => pageErrors.push(error.message));
+
+		await page.goto('/wp-admin/post-new.php?post_type=feedzy_imports');
+		await tryCloseTourModal(page);
+
+		await page.getByRole('button', { name: 'Step 3 Map content ' }).click();
+
+		// Simulate a Tagify build that does not expose the optional persistence API.
+		await page.waitForFunction(
+			(selector) => Boolean(window.jQuery(selector).data('tagify')),
+			featuredImgInput
+		);
+		await page.evaluate((selector) => {
+			const tagify = window.jQuery(selector).data('tagify');
+			delete tagify.clearPersistedData;
+			delete tagify.setPersistedData;
+		}, featuredImgInput);
+
+		// Open the action popup for the featured image tag.
+		await page.locator('.fz-image-action-tags .btn-add-fields').click();
+		await page
+			.locator('.fz-image-action-tags [data-action_popup="item_image"]')
+			.click();
+
+		await expect(
+			page.getByRole('heading', { name: 'Add actions to this tag' })
+		).toBeVisible();
+
+		await page.getByRole('button', { name: 'Skip Actions' }).click();
+
+		// The modal closes and the tag is persisted on the field.
+		await expect(
+			page.getByRole('heading', { name: 'Add actions to this tag' })
+		).not.toBeVisible();
+		await expect
+			.poll(() =>
+				page.evaluate(
+					(selector) => document.querySelector(selector).value,
+					featuredImgInput
+				)
+			)
+			.toContain('item_image');
+		expect(
+			pageErrors.filter((message) => message.includes('PersistedData'))
+		).toEqual([]);
+	});
+
 	test('close Feedzy Action modal when clicking outside', async ({
 		page,
 	}) => {

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -326,7 +326,6 @@ test.describe('Feed Import', () => {
 		await page.evaluate((selector) => {
 			const tagify = window.jQuery(selector).data('tagify');
 			delete tagify.clearPersistedData;
-			delete tagify.setPersistedData;
 		}, featuredImgInput);
 
 		// Open the action popup for the featured image tag.


### PR DESCRIPTION
### Summary
Handled the missing `clearPersistedData` method in the `ActionPopup` component. The code now checks whether the method exists before calling it; if it doesn't, it calls the fallback method `setPersistedData` with an empty array to clear the persisted data.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1305