### PR TITLE
Added fallback for IDN URL validation

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -3040,8 +3040,8 @@ class Feedzy_Rss_Feeds_Import {
 		}
 
 		$host = '';
-		if ( isset( $parts['scheme'] ) ) {
-			$host = idn_to_ascii( $parts['host'], IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+		if ( isset( $parts['host'] ) ) {
+			$host = $this->convert_host_to_ascii( $parts['host'] );
 		}
 
 		$url = $scheme . $host;
@@ -3068,6 +3068,69 @@ class Feedzy_Rss_Feeds_Import {
 			$url .= '#' . $parts['fragment'];
 		}
 		return esc_url( $url );
+	}
+
+	/**
+	 * Converts a host to its IDNA ASCII (punycode) representation.
+	 *
+	 * @param string $host The host to convert.
+	 *
+	 * @return string The ASCII host, or the original host when it cannot be converted.
+	 */
+	private function convert_host_to_ascii( $host ) {
+		// Hosts that are already ASCII need no conversion, so no extension is required for them.
+		if ( '' === $host || ! preg_match( '/[^\x20-\x7F]/', $host ) ) {
+			return $host;
+		}
+
+		if ( function_exists( 'idn_to_ascii' ) ) {
+			if ( defined( 'IDNA_DEFAULT' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
+				$ascii_host = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+			} else {
+				$ascii_host = idn_to_ascii( $host ); // phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
+			}
+
+			if ( is_string( $ascii_host ) && '' !== $ascii_host ) {
+				return $ascii_host;
+			}
+		}
+
+		$ascii_host = $this->punycode_encode_host( $host );
+
+		return '' !== $ascii_host ? $ascii_host : $host;
+	}
+
+	/**
+	 * Encodes a host with the punycode encoder shipped with WordPress core.
+	 *
+	 * Used as the fallback for `idn_to_ascii()` when the `intl` extension is not installed.
+	 *
+	 * @param string $host The host to encode.
+	 *
+	 * @return string The encoded host, or an empty string when it could not be encoded.
+	 */
+	private function punycode_encode_host( $host ) {
+		// `WpOrg\Requests\IdnaEncoder` ships with WordPress 6.2+, `Requests_IDNAEncoder` with older versions.
+		$encoders = array( 'WpOrg\Requests\IdnaEncoder', 'Requests_IDNAEncoder' );
+
+		foreach ( $encoders as $encoder ) {
+			if ( ! class_exists( $encoder ) ) {
+				continue;
+			}
+
+			try {
+				$ascii_host = call_user_func( array( $encoder, 'encode' ), $host );
+			} catch ( Exception $e ) {
+				// Invalid or non-encodable host, e.g. a label that is too long once encoded.
+				return '';
+			}
+
+			if ( is_string( $ascii_host ) ) {
+				return $ascii_host;
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -3083,12 +3083,8 @@ class Feedzy_Rss_Feeds_Import {
 			return $host;
 		}
 
-		if ( function_exists( 'idn_to_ascii' ) ) {
-			if ( defined( 'IDNA_DEFAULT' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
-				$ascii_host = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
-			} else {
-				$ascii_host = idn_to_ascii( $host ); // phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
-			}
+		if ( function_exists( 'idn_to_ascii' ) && defined( 'IDNA_DEFAULT' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
+			$ascii_host = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
 
 			if ( is_string( $ascii_host ) && '' !== $ascii_host ) {
 				return $ascii_host;

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -169,4 +169,100 @@ class Test_Image_Import extends WP_UnitTestCase {
 		$this->assertTrue( empty( $import_errors ) );
 
 	}
+
+	/**
+	 * Internationalized image URLs must be converted to their ASCII representation so that
+	 * FILTER_VALIDATE_URL accepts them.
+	 */
+	public function test_convert_url_to_ascii_converts_internationalized_urls() {
+		$feedzy    = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$reflector = new ReflectionClass( $feedzy );
+		$convert   = $reflector->getMethod( 'convert_url_to_ascii' );
+		$convert->setAccessible( true );
+
+		$cases = array(
+			// ASCII URLs are left untouched.
+			'https://example.com/wp-content/uploads/image.jpg' => 'https://example.com/wp-content/uploads/image.jpg',
+			// The host is punycoded and the path is percent encoded.
+			'https://bücher.example.com/path/ïmage.jpg'        => 'https://xn--bcher-kva.example.com/path/%C3%AFmage.jpg',
+			// Already punycoded hosts stay as they are.
+			'https://xn--bcher-kva.example.com/image.jpg'      => 'https://xn--bcher-kva.example.com/image.jpg',
+			// Ports and query strings are preserved.
+			'https://münchen.de:8080/image.jpg?itok=ZYU_ihPB'  => 'https://xn--mnchen-3ya.de:8080/image.jpg?itok=ZYU_ihPB',
+		);
+
+		foreach ( $cases as $url => $expected ) {
+			$actual = $convert->invoke( $feedzy, $url );
+			$this->assertSame( $expected, $actual, 'Unexpected ASCII conversion for ' . $url );
+			$this->assertNotFalse( filter_var( $actual, FILTER_VALIDATE_URL ), 'Converted URL should validate: ' . $actual );
+		}
+
+		// Protocol relative URLs keep their host.
+		$this->assertStringContainsString( 'xn--bcher-kva.example.com', $convert->invoke( $feedzy, '//bücher.example.com/image.jpg' ) );
+	}
+
+	/**
+	 * `idn_to_ascii()` belongs to the optional `intl` extension, so the conversion must not
+	 * depend on it. The punycode fallback bundled with WordPress has to return the same host,
+	 * and an unconvertible host must degrade gracefully instead of raising a fatal error.
+	 * See https://github.com/Codeinwp/feedzy-rss-feeds/issues/1289.
+	 */
+	public function test_convert_host_to_ascii_without_intl_extension() {
+		$feedzy    = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$reflector = new ReflectionClass( $feedzy );
+
+		// The fallback used when `idn_to_ascii()` is undefined.
+		$fallback = $reflector->getMethod( 'punycode_encode_host' );
+		$fallback->setAccessible( true );
+
+		$this->assertSame( 'xn--bcher-kva.example.com', $fallback->invoke( $feedzy, 'bücher.example.com' ) );
+		$this->assertSame( 'xn--r8jz45g.xn--zckzah', $fallback->invoke( $feedzy, '例え.テスト' ) );
+
+		// A host that cannot be encoded yields an empty string rather than an uncaught exception.
+		$unconvertible = str_repeat( 'ä', 200 ) . '.com';
+		$this->assertSame( '', $fallback->invoke( $feedzy, $unconvertible ) );
+
+		$convert_host = $reflector->getMethod( 'convert_host_to_ascii' );
+		$convert_host->setAccessible( true );
+
+		// ASCII hosts need no conversion at all, so no extension is involved.
+		$this->assertSame( 'example.com', $convert_host->invoke( $feedzy, 'example.com' ) );
+		$this->assertSame( '', $convert_host->invoke( $feedzy, '' ) );
+
+		// When neither path can convert the host it is returned unchanged.
+		$this->assertSame( $unconvertible, $convert_host->invoke( $feedzy, $unconvertible ) );
+	}
+
+	/**
+	 * The featured image cron must keep running when an internationalized URL is imported,
+	 * no matter whether the `intl` extension is installed.
+	 */
+	public function test_try_save_featured_image_with_internationalized_url() {
+		$feedzy    = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$reflector = new ReflectionClass( $feedzy );
+
+		$try_save_featured_image = $reflector->getMethod( 'try_save_featured_image' );
+		$try_save_featured_image->setAccessible( true );
+
+		$logged = array();
+		add_filter(
+			'themeisle_log_event',
+			function ( $product, $message, $type ) use ( &$logged ) {
+				$logged[] = array( $type, $message );
+			},
+			10,
+			5
+		);
+
+		$import_info = array();
+		$arguments   = array( 'https://bücher.example.com/path_to_image/ïmage.jpg', 0, 'Post Title', &$import_info, array() );
+		$response    = $try_save_featured_image->invokeArgs( $feedzy, $arguments );
+
+		// The image does not exist, so the download fails, but the URL itself must pass validation.
+		$this->assertFalse( $response );
+
+		foreach ( $logged as $entry ) {
+			$this->assertStringNotContainsString( 'Invalid image URL', $entry[1], 'Internationalized URL should not be rejected as invalid' );
+		}
+	}
 }

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -244,14 +244,15 @@ class Test_Image_Import extends WP_UnitTestCase {
 		$try_save_featured_image = $reflector->getMethod( 'try_save_featured_image' );
 		$try_save_featured_image->setAccessible( true );
 
-		$logged = array();
+		$requested_urls = array();
 		add_filter(
-			'themeisle_log_event',
-			function ( $product, $message, $type ) use ( &$logged ) {
-				$logged[] = array( $type, $message );
+			'pre_http_request',
+			function ( $preempt, $request_args, $url ) use ( &$requested_urls ) {
+ 				$requested_urls[] = $url;
+ 				return new WP_Error( 'test_download_failure', 'Expected test download failure.' );
 			},
 			10,
-			5
+			3
 		);
 
 		$import_info = array();
@@ -261,8 +262,6 @@ class Test_Image_Import extends WP_UnitTestCase {
 		// The image does not exist, so the download fails, but the URL itself must pass validation.
 		$this->assertFalse( $response );
 
-		foreach ( $logged as $entry ) {
-			$this->assertStringNotContainsString( 'Invalid image URL', $entry[1], 'Internationalized URL should not be rejected as invalid' );
-		}
+		$this->assertNotEmpty( $requested_urls, 'Internationalized URL should pass validation and reach the HTTP layer.' );
 	}
 }

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -248,8 +248,8 @@ class Test_Image_Import extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $request_args, $url ) use ( &$requested_urls ) {
- 				$requested_urls[] = $url;
- 				return new WP_Error( 'test_download_failure', 'Expected test download failure.' );
+				$requested_urls[] = $url;
+				return new WP_Error( 'test_download_failure', 'Expected test download failure.' );
 			},
 			10,
 			3


### PR DESCRIPTION
### Summary
Added a fallback for the `idn_to_ascii()` function in case the `intl` extension is not available. This ensures that the plugin can handle internationalized domain names (IDNs) correctly, even on servers without the `intl` extension.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1302