### PR TITLE
Restored legacy deletion settings to existing imports

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -569,6 +569,18 @@ class Feedzy_Rss_Feeds_Import {
 			$import_feed_limit = 10;
 		}
 
+		$has_import_feed_delete_days = metadata_exists( 'post', $post->ID, 'import_feed_delete_days' );
+		$import_feed_delete_days     = intval( get_post_meta( $post->ID, 'import_feed_delete_days', true ) );
+		if ( empty( $import_feed_delete_days ) ) {
+			$import_feed_delete_days = ! empty( $this->free_settings['general']['feedzy-delete-days'] ) ? (int) $this->free_settings['general']['feedzy-delete-days'] : 0;
+		}
+
+		$has_import_feed_delete_media = metadata_exists( 'post', $post->ID, 'import_feed_delete_media' );
+		$import_feed_delete_media     = get_post_meta( $post->ID, 'import_feed_delete_media', true );
+		if ( empty( $import_feed_delete_media ) ) {
+			$import_feed_delete_media = ! empty( $this->free_settings['general']['feedzy-delete-media'] ) ? 'yes' : 'no';
+		}
+
 		$default_thumbnail_id   = 0;
 		$inherited_thumbnail_id = ! empty( $this->free_settings['general']['default-thumbnail-id'] ) ? (int) $this->free_settings['general']['default-thumbnail-id'] : 0;
 		$custom_thumbnail_id    = get_post_meta( $post->ID, 'default_thumbnail_id', true );
@@ -714,6 +726,11 @@ class Feedzy_Rss_Feeds_Import {
 				$data_meta['filter_conditions'] = wp_slash( $data_meta['filter_conditions'] );
 			}
 
+			// This legacy setting is only rendered for imports that already store it, so don't create it for the rest.
+			if ( ! isset( $data_meta['import_feed_delete_media'] ) && metadata_exists( 'post', $post_id, 'import_feed_delete_media' ) ) {
+				$data_meta['import_feed_delete_media'] = 'no';
+			}
+
 			// $data_meta['feedzy_post_author'] should be the author username. We convert it to the author ID.
 			if ( ! empty( $data_meta['import_post_author'] ) ) {
 				$author = get_user_by( 'login', $data_meta['import_post_author'] );
@@ -743,7 +760,7 @@ class Feedzy_Rss_Feeds_Import {
 					add_post_meta( $post_id, $key, $value );
 				}
 				if ( ! $value ) {
-					if ( 'default_thumbnail_id' === $key && '0' === $value ) { // Mark the feed as having no default fallback image (including the global fallback).
+					if ( ( 'default_thumbnail_id' === $key || 'import_feed_delete_days' === $key ) && '0' === $value ) { // Mark the feed as having no default fallback image or auto-delete days (including the global fallback).
 						continue;
 					}
 					delete_post_meta( $post_id, $key );

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -571,7 +571,7 @@ class Feedzy_Rss_Feeds_Import {
 
 		$has_import_feed_delete_days = metadata_exists( 'post', $post->ID, 'import_feed_delete_days' );
 		$import_feed_delete_days     = intval( get_post_meta( $post->ID, 'import_feed_delete_days', true ) );
-		if ( empty( $import_feed_delete_days ) ) {
+		if ( ! $has_import_feed_delete_days ) {
 			$import_feed_delete_days = ! empty( $this->free_settings['general']['feedzy-delete-days'] ) ? (int) $this->free_settings['general']['feedzy-delete-days'] : 0;
 		}
 

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -731,6 +731,12 @@ class Feedzy_Rss_Feeds_Import {
 				$data_meta['import_feed_delete_media'] = 'no';
 			}
 
+			// The Auto-Delete field is optional, so clearing it submits an empty string. Normalize it to the
+			// documented 0 ("never delete") state so the value is kept instead of falling back to the global one.
+			if ( isset( $data_meta['import_feed_delete_days'] ) ) {
+				$data_meta['import_feed_delete_days'] = (string) absint( $data_meta['import_feed_delete_days'] );
+			}
+
 			// $data_meta['feedzy_post_author'] should be the author username. We convert it to the author ID.
 			if ( ! empty( $data_meta['import_post_author'] ) ) {
 				$author = get_user_by( 'login', $data_meta['import_post_author'] );

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -837,7 +837,7 @@ global $post;
 									</div>
 									<div class="fz-right">
 										<div class="fz-form-group">
-											<label class="form-label"><?php esc_html_e( 'Delete the posts created for this import after a number of days', 'feedzy-rss-feeds' ); ?></label>
+											<label class="form-label" for="feedzy_delete_days"><?php esc_html_e( 'Delete the posts created for this import after a number of days', 'feedzy-rss-feeds' ); ?></label>
 											<input type="number" min="0" max="9999" id="feedzy_delete_days" name="feedzy_meta_data[import_feed_delete_days]" class="form-control" value="<?php echo (int) esc_attr( isset( $import_feed_delete_days ) ? $import_feed_delete_days : 0 ); ?>" />
 											<div class="help-text pt-8">
 												<?php esc_html_e( 'Helpful if you want to remove stale or old items automatically. Choose 0, and the imported items will not be automatically deleted.', 'feedzy-rss-feeds' ); ?>

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -828,6 +828,45 @@ global $post;
 									</div>
 								</div>
 							</div>
+
+							<?php if ( isset( $has_import_feed_delete_days ) && $has_import_feed_delete_days ) : ?>
+								<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
+									<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'auto-delete', 'import' ) ); ?>
+									<div class="fz-left">
+										<h4 class="h4"><?php esc_html_e( 'Auto-Delete', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
+									</div>
+									<div class="fz-right">
+										<div class="fz-form-group">
+											<label class="form-label"><?php esc_html_e( 'Delete the posts created for this import after a number of days', 'feedzy-rss-feeds' ); ?></label>
+											<input type="number" min="0" max="9999" id="feedzy_delete_days" name="feedzy_meta_data[import_feed_delete_days]" class="form-control" value="<?php echo (int) esc_attr( isset( $import_feed_delete_days ) ? $import_feed_delete_days : 0 ); ?>" />
+											<div class="help-text pt-8">
+												<?php esc_html_e( 'Helpful if you want to remove stale or old items automatically. Choose 0, and the imported items will not be automatically deleted.', 'feedzy-rss-feeds' ); ?>
+											</div>
+										</div>
+									</div>
+								</div>
+							<?php endif; ?>
+
+							<?php if ( isset( $has_import_feed_delete_media ) && $has_import_feed_delete_media ) : ?>
+								<div class="form-block form-block-two-column no-border <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
+									<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'delete-featured-image', 'import' ) ); ?>
+									<div class="fz-left"><h4 class="h4"><?php esc_html_e( 'Delete image', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
+									</div>
+									<div class="fz-right">
+										<div class="fz-form-group">
+											<div class="fz-form-switch">
+												<input id="delete-attached-media" name="feedzy_meta_data[import_feed_delete_media]"
+												class="fz-switch-toggle" type="checkbox" value="yes"
+												<?php echo esc_attr( ( isset( $import_feed_delete_media ) && 'yes' === $import_feed_delete_media ) ? 'checked' : '' ); ?>>
+												<label class="feedzy-inline form-label" for="delete-attached-media"><?php esc_html_e( 'Delete attached featured image', 'feedzy-rss-feeds' ); ?></label>
+											</div>
+											<div class="help-text">
+												<?php echo wp_sprintf( esc_html__( 'Helpful if you want to delete attached featured image when posts are automatically deleted.', 'feedzy-rss-feeds' ) ); ?>
+											</div>
+										</div>
+									</div>
+								</div>
+							<?php endif; ?>
 						</div>
 					</div>
 					<div class="fz-tab-content" id="fz-advanced-settings">

--- a/includes/views/import-metabox-edit.php
+++ b/includes/views/import-metabox-edit.php
@@ -833,7 +833,7 @@ global $post;
 								<div class="form-block form-block-two-column <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 									<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'auto-delete', 'import' ) ); ?>
 									<div class="fz-left">
-										<h4 class="h4"><?php esc_html_e( 'Auto-Delete', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
+										<h4 class="h4"><?php esc_html_e( 'Delete', 'feedzy-rss-feeds' ); ?> <?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 									</div>
 									<div class="fz-right">
 										<div class="fz-form-group">
@@ -850,7 +850,7 @@ global $post;
 							<?php if ( isset( $has_import_feed_delete_media ) && $has_import_feed_delete_media ) : ?>
 								<div class="form-block form-block-two-column no-border <?php echo esc_attr( apply_filters( 'feedzy_upsell_class', '' ) ); ?>">
 									<?php echo wp_kses_post( apply_filters( 'feedzy_upsell_content', '', 'delete-featured-image', 'import' ) ); ?>
-									<div class="fz-left"><h4 class="h4"><?php esc_html_e( 'Delete image', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
+									<div class="fz-left"><h4 class="h4"><?php esc_html_e( 'Remove image', 'feedzy-rss-feeds' ); ?><?php echo ! feedzy_is_pro() ? ' <span class="pro-label">PRO</span>' : ''; ?></h4>
 									</div>
 									<div class="fz-right">
 										<div class="fz-form-group">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,6 +27,11 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/feedzy-rss-feed.php';
+
+	// Composer autoloads the SDK loader before ABSPATH exists, so it bails out before declaring its helpers.
+	if ( ! function_exists( 'tsdk_translate_link' ) ) {
+		require dirname( dirname( __FILE__ ) ) . '/vendor/codeinwp/themeisle-sdk/load.php';
+	}
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/test-import-legacy-settings.php
+++ b/tests/test-import-legacy-settings.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for the legacy Auto-Delete / Delete image import settings.
+ *
+ * @package     feedzy-rss-feeds
+ * @subpackage  Tests
+ */
+class Test_Feedzy_Import_Legacy_Settings extends WP_UnitTestCase {
+
+	/**
+	 * The import instance under test.
+	 *
+	 * @var Feedzy_Rss_Feeds_Import
+	 */
+	private $import;
+
+	/**
+	 * Sets up the test methods.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+
+		$this->import = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', Feedzy_Rss_Feeds::get_version() );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Renders the import metabox for a given import job.
+	 *
+	 * @param int $import_id The import job ID.
+	 *
+	 * @return string The rendered markup.
+	 */
+	private function render_metabox( $import_id ) {
+		global $post, $pagenow;
+
+		$previous_post    = $post;
+		$previous_pagenow = $pagenow;
+
+		$post    = get_post( $import_id );
+		$pagenow = 'post.php';
+
+		ob_start();
+		$this->import->feedzy_import_feed_options();
+		$markup = ob_get_clean();
+
+		$post    = $previous_post;
+		$pagenow = $previous_pagenow;
+
+		return $markup;
+	}
+
+	/**
+	 * Creates an import job.
+	 *
+	 * @return int The import job ID.
+	 */
+	private function create_import() {
+		return $this->factory->post->create(
+			array(
+				'post_type'   => 'feedzy_imports',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * An import job without the legacy meta does not render either setting.
+	 */
+	public function test_legacy_settings_are_hidden_for_new_imports() {
+		$markup = $this->render_metabox( $this->create_import() );
+
+		$this->assertStringNotContainsString( 'feedzy_meta_data[import_feed_delete_days]', $markup );
+		$this->assertStringNotContainsString( 'feedzy_meta_data[import_feed_delete_media]', $markup );
+	}
+
+	/**
+	 * An import job that already stores `import_feed_delete_days` still renders the Auto-Delete setting.
+	 */
+	public function test_delete_days_is_shown_when_previously_saved() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_days', '15' );
+
+		$markup = $this->render_metabox( $import_id );
+
+		$this->assertStringContainsString( 'feedzy_meta_data[import_feed_delete_days]', $markup );
+		$this->assertStringContainsString( 'value="15"', $markup );
+		$this->assertStringNotContainsString( 'feedzy_meta_data[import_feed_delete_media]', $markup );
+	}
+
+	/**
+	 * An import job that already stores `import_feed_delete_media` still renders the Delete image setting.
+	 */
+	public function test_delete_media_is_shown_when_previously_saved() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_media', 'yes' );
+
+		$markup = $this->render_metabox( $import_id );
+
+		$this->assertStringContainsString( 'feedzy_meta_data[import_feed_delete_media]', $markup );
+		$this->assertStringNotContainsString( 'feedzy_meta_data[import_feed_delete_days]', $markup );
+	}
+
+	/**
+	 * The disabled state is stored as `no`, which still counts as previously configured.
+	 */
+	public function test_delete_media_is_shown_when_saved_as_no() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_media', 'no' );
+
+		$markup = $this->render_metabox( $import_id );
+
+		$this->assertStringContainsString( 'feedzy_meta_data[import_feed_delete_media]', $markup );
+	}
+
+	/**
+	 * Saving an import that never had the legacy media setting must not create it.
+	 */
+	public function test_saving_does_not_create_delete_media_meta_for_new_imports() {
+		$import_id = $this->create_import();
+		$post      = get_post( $import_id );
+
+		$_POST['feedzy_category_meta_noncename'] = wp_create_nonce( FEEDZY_BASEFILE );
+		$_POST['feedzy_post_nonce']              = wp_create_nonce( 'feedzy_post_nonce' );
+		$_POST['post_type']                      = 'feedzy_imports';
+		$_POST['feedzy_meta_data']               = array(
+			'source'             => 'http://example.com/feed',
+			'import_post_type'   => 'post',
+			'import_post_status' => 'publish',
+			'import_post_title'  => '[#item_title]',
+		);
+		$_POST['custom_vars_key']                = array();
+		$_POST['custom_vars_value']              = array();
+
+		do_action( 'save_post_feedzy_imports', $import_id, $post );
+
+		$this->assertFalse( metadata_exists( 'post', $import_id, 'import_feed_delete_media' ) );
+	}
+
+	/**
+	 * Unchecking the toggle on an import that already stores the setting keeps persisting `no`.
+	 */
+	public function test_saving_keeps_delete_media_meta_for_existing_imports() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_media', 'yes' );
+		$post = get_post( $import_id );
+
+		$_POST['feedzy_category_meta_noncename'] = wp_create_nonce( FEEDZY_BASEFILE );
+		$_POST['feedzy_post_nonce']              = wp_create_nonce( 'feedzy_post_nonce' );
+		$_POST['post_type']                      = 'feedzy_imports';
+		$_POST['feedzy_meta_data']               = array(
+			'source'             => 'http://example.com/feed',
+			'import_post_type'   => 'post',
+			'import_post_status' => 'publish',
+			'import_post_title'  => '[#item_title]',
+		);
+		$_POST['custom_vars_key']                = array();
+		$_POST['custom_vars_value']              = array();
+
+		do_action( 'save_post_feedzy_imports', $import_id, $post );
+
+		$this->assertSame( 'no', get_post_meta( $import_id, 'import_feed_delete_media', true ) );
+	}
+}

--- a/tests/test-import-legacy-settings.php
+++ b/tests/test-import-legacy-settings.php
@@ -117,25 +117,37 @@ class Test_Feedzy_Import_Legacy_Settings extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Saving an import that never had the legacy media setting must not create it.
+	 * Submits the import metabox form for a given import job.
+	 *
+	 * @param int   $import_id  The import job ID.
+	 * @param array $extra_meta Extra `feedzy_meta_data` fields to submit.
 	 */
-	public function test_saving_does_not_create_delete_media_meta_for_new_imports() {
-		$import_id = $this->create_import();
-		$post      = get_post( $import_id );
-
+	private function save_import( $import_id, $extra_meta = array() ) {
 		$_POST['feedzy_category_meta_noncename'] = wp_create_nonce( FEEDZY_BASEFILE );
 		$_POST['feedzy_post_nonce']              = wp_create_nonce( 'feedzy_post_nonce' );
 		$_POST['post_type']                      = 'feedzy_imports';
-		$_POST['feedzy_meta_data']               = array(
-			'source'             => 'http://example.com/feed',
-			'import_post_type'   => 'post',
-			'import_post_status' => 'publish',
-			'import_post_title'  => '[#item_title]',
+		$_POST['feedzy_meta_data']               = array_merge(
+			array(
+				'source'             => 'http://example.com/feed',
+				'import_post_type'   => 'post',
+				'import_post_status' => 'publish',
+				'import_post_title'  => '[#item_title]',
+			),
+			$extra_meta
 		);
 		$_POST['custom_vars_key']                = array();
 		$_POST['custom_vars_value']              = array();
 
-		do_action( 'save_post_feedzy_imports', $import_id, $post );
+		do_action( 'save_post_feedzy_imports', $import_id, get_post( $import_id ) );
+	}
+
+	/**
+	 * Saving an import that never had the legacy media setting must not create it.
+	 */
+	public function test_saving_does_not_create_delete_media_meta_for_new_imports() {
+		$import_id = $this->create_import();
+
+		$this->save_import( $import_id );
 
 		$this->assertFalse( metadata_exists( 'post', $import_id, 'import_feed_delete_media' ) );
 	}
@@ -146,22 +158,77 @@ class Test_Feedzy_Import_Legacy_Settings extends WP_UnitTestCase {
 	public function test_saving_keeps_delete_media_meta_for_existing_imports() {
 		$import_id = $this->create_import();
 		update_post_meta( $import_id, 'import_feed_delete_media', 'yes' );
-		$post = get_post( $import_id );
 
-		$_POST['feedzy_category_meta_noncename'] = wp_create_nonce( FEEDZY_BASEFILE );
-		$_POST['feedzy_post_nonce']              = wp_create_nonce( 'feedzy_post_nonce' );
-		$_POST['post_type']                      = 'feedzy_imports';
-		$_POST['feedzy_meta_data']               = array(
-			'source'             => 'http://example.com/feed',
-			'import_post_type'   => 'post',
-			'import_post_status' => 'publish',
-			'import_post_title'  => '[#item_title]',
-		);
-		$_POST['custom_vars_key']                = array();
-		$_POST['custom_vars_value']              = array();
-
-		do_action( 'save_post_feedzy_imports', $import_id, $post );
+		$this->save_import( $import_id );
 
 		$this->assertSame( 'no', get_post_meta( $import_id, 'import_feed_delete_media', true ) );
+	}
+
+	/**
+	 * Saving an import that never had the legacy Auto-Delete setting must not create it.
+	 */
+	public function test_saving_does_not_create_delete_days_meta_for_new_imports() {
+		$import_id = $this->create_import();
+
+		$this->save_import( $import_id );
+
+		$this->assertFalse( metadata_exists( 'post', $import_id, 'import_feed_delete_days' ) );
+	}
+
+	/**
+	 * Clearing the optional Auto-Delete field submits an empty string, which must be stored as 0
+	 * rather than dropping the meta and letting the import inherit the global deletion period.
+	 */
+	public function test_clearing_delete_days_stores_zero_instead_of_dropping_the_meta() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_days', '15' );
+
+		$this->save_import( $import_id, array( 'import_feed_delete_days' => '' ) );
+
+		$this->assertTrue( metadata_exists( 'post', $import_id, 'import_feed_delete_days' ) );
+		$this->assertSame( '0', get_post_meta( $import_id, 'import_feed_delete_days', true ) );
+	}
+
+	/**
+	 * Submitting an explicit 0 keeps the meta too, so the setting stays visible.
+	 */
+	public function test_saving_zero_delete_days_keeps_the_meta() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_days', '15' );
+
+		$this->save_import( $import_id, array( 'import_feed_delete_days' => '0' ) );
+
+		$this->assertSame( '0', get_post_meta( $import_id, 'import_feed_delete_days', true ) );
+	}
+
+	/**
+	 * An import with Auto-Delete cleared still renders the setting, and does not inherit the global period.
+	 */
+	public function test_cleared_delete_days_still_renders_and_ignores_the_global_default() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_days', '15' );
+		update_option( 'feedzy-settings', array( 'general' => array( 'feedzy-delete-days' => 30 ) ) );
+
+		// The global settings are read in the constructor, so pick up the one set above.
+		$this->import = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', Feedzy_Rss_Feeds::get_version() );
+
+		$this->save_import( $import_id, array( 'import_feed_delete_days' => '' ) );
+
+		$markup = $this->render_metabox( $import_id );
+
+		$this->assertStringContainsString( 'feedzy_meta_data[import_feed_delete_days]', $markup );
+		$this->assertStringContainsString( 'id="feedzy_delete_days" name="feedzy_meta_data[import_feed_delete_days]" class="form-control" value="0"', $markup );
+	}
+
+	/**
+	 * A non-numeric Auto-Delete value falls back to 0 rather than being stored verbatim.
+	 */
+	public function test_non_numeric_delete_days_is_normalized_to_zero() {
+		$import_id = $this->create_import();
+		update_post_meta( $import_id, 'import_feed_delete_days', '15' );
+
+		$this->save_import( $import_id, array( 'import_feed_delete_days' => 'abc' ) );
+
+		$this->assertSame( '0', get_post_meta( $import_id, 'import_feed_delete_days', true ) );
 	}
 }


### PR DESCRIPTION
### Summary
Restored the legacy setting - auto-delete days for imported posts and delete attached media. The setting is only rendered for imports that already have it stored, so it won't create it for the rest.

### Screenshots
<img width="1076" height="388" alt="image" src="https://github.com/user-attachments/assets/3e1cb58e-9ba1-4d39-b4f1-cf563d05d7ed" />


### Test instructions
- Create a new import and set up the auto-delete days and delete attached media settings from the older version.
- Verify that the settings are displayed in the import edit page and that they are saved correctly when updated.
- Also verify that the settings are not displayed for new imports that don't have them stored.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/1010