### PR TITLE
Release

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -3040,8 +3040,8 @@ class Feedzy_Rss_Feeds_Import {
 		}
 
 		$host = '';
-		if ( isset( $parts['scheme'] ) ) {
-			$host = idn_to_ascii( $parts['host'], IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+		if ( isset( $parts['host'] ) ) {
+			$host = $this->convert_host_to_ascii( $parts['host'] );
 		}
 
 		$url = $scheme . $host;
@@ -3068,6 +3068,69 @@ class Feedzy_Rss_Feeds_Import {
 			$url .= '#' . $parts['fragment'];
 		}
 		return esc_url( $url );
+	}
+
+	/**
+	 * Converts a host to its IDNA ASCII (punycode) representation.
+	 *
+	 * @param string $host The host to convert.
+	 *
+	 * @return string The ASCII host, or the original host when it cannot be converted.
+	 */
+	private function convert_host_to_ascii( $host ) {
+		// Hosts that are already ASCII need no conversion, so no extension is required for them.
+		if ( '' === $host || ! preg_match( '/[^\x20-\x7F]/', $host ) ) {
+			return $host;
+		}
+
+		if ( function_exists( 'idn_to_ascii' ) ) {
+			if ( defined( 'IDNA_DEFAULT' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
+				$ascii_host = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+			} else {
+				$ascii_host = idn_to_ascii( $host ); // phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
+			}
+
+			if ( is_string( $ascii_host ) && '' !== $ascii_host ) {
+				return $ascii_host;
+			}
+		}
+
+		$ascii_host = $this->punycode_encode_host( $host );
+
+		return '' !== $ascii_host ? $ascii_host : $host;
+	}
+
+	/**
+	 * Encodes a host with the punycode encoder shipped with WordPress core.
+	 *
+	 * Used as the fallback for `idn_to_ascii()` when the `intl` extension is not installed.
+	 *
+	 * @param string $host The host to encode.
+	 *
+	 * @return string The encoded host, or an empty string when it could not be encoded.
+	 */
+	private function punycode_encode_host( $host ) {
+		// `WpOrg\Requests\IdnaEncoder` ships with WordPress 6.2+, `Requests_IDNAEncoder` with older versions.
+		$encoders = array( 'WpOrg\Requests\IdnaEncoder', 'Requests_IDNAEncoder' );
+
+		foreach ( $encoders as $encoder ) {
+			if ( ! class_exists( $encoder ) ) {
+				continue;
+			}
+
+			try {
+				$ascii_host = call_user_func( array( $encoder, 'encode' ), $host );
+			} catch ( Exception $e ) {
+				// Invalid or non-encodable host, e.g. a label that is too long once encoded.
+				return '';
+			}
+
+			if ( is_string( $ascii_host ) ) {
+				return $ascii_host;
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -3083,12 +3083,8 @@ class Feedzy_Rss_Feeds_Import {
 			return $host;
 		}
 
-		if ( function_exists( 'idn_to_ascii' ) ) {
-			if ( defined( 'IDNA_DEFAULT' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
-				$ascii_host = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
-			} else {
-				$ascii_host = idn_to_ascii( $host ); // phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
-			}
+		if ( function_exists( 'idn_to_ascii' ) && defined( 'IDNA_DEFAULT' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
+			$ascii_host = idn_to_ascii( $host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
 
 			if ( is_string( $ascii_host ) && '' !== $ascii_host ) {
 				return $ascii_host;

--- a/js/ActionPopup/index.js
+++ b/js/ActionPopup/index.js
@@ -17,6 +17,21 @@ import {
 
 import { Icon, dragHandle, close, plus, trash } from '@wordpress/icons';
 
+/**
+ * Drop the data Tagify keeps in the browser storage for the given instance.
+ *
+ * @param {Object} tagify The Tagify instance.
+ */
+const clearTagifyPersistedData = (tagify) => {
+	if ('function' === typeof tagify?.clearPersistedData) {
+		tagify.clearPersistedData();
+		return;
+	}
+	if ('function' === typeof tagify?.setPersistedData) {
+		tagify.setPersistedData([], 'value');
+	}
+};
+
 const ActionModal = () => {
 	// useRef
 	const userRef = useRef(null);
@@ -236,7 +251,7 @@ const ActionModal = () => {
 		if ('import_post_featured_img' === fieldName) {
 			inputField.removeAllTags();
 			inputField.addEmptyTag();
-			inputField.clearPersistedData();
+			clearTagifyPersistedData(inputField);
 		}
 		if (null === editModeTag || 'import_post_featured_img' === fieldName) {
 			const tagElm = inputField.createTagElem({ value: _action });

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -305,6 +305,59 @@ test.describe('Feed Import', () => {
 		).resolves.toBeGreaterThan(0); // We should have some imported images.
 	});
 
+	test('save featured image action when Tagify has no persistence API', async ({
+		page,
+	}) => {
+		const featuredImgInput =
+			'input[name="feedzy_meta_data[import_post_featured_img]"]';
+		const pageErrors = [];
+		page.on('pageerror', (error) => pageErrors.push(error.message));
+
+		await page.goto('/wp-admin/post-new.php?post_type=feedzy_imports');
+		await tryCloseTourModal(page);
+
+		await page.getByRole('button', { name: 'Step 3 Map content ' }).click();
+
+		// Simulate a Tagify build that does not expose the optional persistence API.
+		await page.waitForFunction(
+			(selector) => Boolean(window.jQuery(selector).data('tagify')),
+			featuredImgInput
+		);
+		await page.evaluate((selector) => {
+			const tagify = window.jQuery(selector).data('tagify');
+			delete tagify.clearPersistedData;
+			delete tagify.setPersistedData;
+		}, featuredImgInput);
+
+		// Open the action popup for the featured image tag.
+		await page.locator('.fz-image-action-tags .btn-add-fields').click();
+		await page
+			.locator('.fz-image-action-tags [data-action_popup="item_image"]')
+			.click();
+
+		await expect(
+			page.getByRole('heading', { name: 'Add actions to this tag' })
+		).toBeVisible();
+
+		await page.getByRole('button', { name: 'Skip Actions' }).click();
+
+		// The modal closes and the tag is persisted on the field.
+		await expect(
+			page.getByRole('heading', { name: 'Add actions to this tag' })
+		).not.toBeVisible();
+		await expect
+			.poll(() =>
+				page.evaluate(
+					(selector) => document.querySelector(selector).value,
+					featuredImgInput
+				)
+			)
+			.toContain('item_image');
+		expect(
+			pageErrors.filter((message) => message.includes('PersistedData'))
+		).toEqual([]);
+	});
+
 	test('close Feedzy Action modal when clicking outside', async ({
 		page,
 	}) => {

--- a/tests/e2e/specs/import.spec.js
+++ b/tests/e2e/specs/import.spec.js
@@ -326,7 +326,6 @@ test.describe('Feed Import', () => {
 		await page.evaluate((selector) => {
 			const tagify = window.jQuery(selector).data('tagify');
 			delete tagify.clearPersistedData;
-			delete tagify.setPersistedData;
 		}, featuredImgInput);
 
 		// Open the action popup for the featured image tag.

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -169,4 +169,100 @@ class Test_Image_Import extends WP_UnitTestCase {
 		$this->assertTrue( empty( $import_errors ) );
 
 	}
+
+	/**
+	 * Internationalized image URLs must be converted to their ASCII representation so that
+	 * FILTER_VALIDATE_URL accepts them.
+	 */
+	public function test_convert_url_to_ascii_converts_internationalized_urls() {
+		$feedzy    = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$reflector = new ReflectionClass( $feedzy );
+		$convert   = $reflector->getMethod( 'convert_url_to_ascii' );
+		$convert->setAccessible( true );
+
+		$cases = array(
+			// ASCII URLs are left untouched.
+			'https://example.com/wp-content/uploads/image.jpg' => 'https://example.com/wp-content/uploads/image.jpg',
+			// The host is punycoded and the path is percent encoded.
+			'https://bücher.example.com/path/ïmage.jpg'        => 'https://xn--bcher-kva.example.com/path/%C3%AFmage.jpg',
+			// Already punycoded hosts stay as they are.
+			'https://xn--bcher-kva.example.com/image.jpg'      => 'https://xn--bcher-kva.example.com/image.jpg',
+			// Ports and query strings are preserved.
+			'https://münchen.de:8080/image.jpg?itok=ZYU_ihPB'  => 'https://xn--mnchen-3ya.de:8080/image.jpg?itok=ZYU_ihPB',
+		);
+
+		foreach ( $cases as $url => $expected ) {
+			$actual = $convert->invoke( $feedzy, $url );
+			$this->assertSame( $expected, $actual, 'Unexpected ASCII conversion for ' . $url );
+			$this->assertNotFalse( filter_var( $actual, FILTER_VALIDATE_URL ), 'Converted URL should validate: ' . $actual );
+		}
+
+		// Protocol relative URLs keep their host.
+		$this->assertStringContainsString( 'xn--bcher-kva.example.com', $convert->invoke( $feedzy, '//bücher.example.com/image.jpg' ) );
+	}
+
+	/**
+	 * `idn_to_ascii()` belongs to the optional `intl` extension, so the conversion must not
+	 * depend on it. The punycode fallback bundled with WordPress has to return the same host,
+	 * and an unconvertible host must degrade gracefully instead of raising a fatal error.
+	 * See https://github.com/Codeinwp/feedzy-rss-feeds/issues/1289.
+	 */
+	public function test_convert_host_to_ascii_without_intl_extension() {
+		$feedzy    = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$reflector = new ReflectionClass( $feedzy );
+
+		// The fallback used when `idn_to_ascii()` is undefined.
+		$fallback = $reflector->getMethod( 'punycode_encode_host' );
+		$fallback->setAccessible( true );
+
+		$this->assertSame( 'xn--bcher-kva.example.com', $fallback->invoke( $feedzy, 'bücher.example.com' ) );
+		$this->assertSame( 'xn--r8jz45g.xn--zckzah', $fallback->invoke( $feedzy, '例え.テスト' ) );
+
+		// A host that cannot be encoded yields an empty string rather than an uncaught exception.
+		$unconvertible = str_repeat( 'ä', 200 ) . '.com';
+		$this->assertSame( '', $fallback->invoke( $feedzy, $unconvertible ) );
+
+		$convert_host = $reflector->getMethod( 'convert_host_to_ascii' );
+		$convert_host->setAccessible( true );
+
+		// ASCII hosts need no conversion at all, so no extension is involved.
+		$this->assertSame( 'example.com', $convert_host->invoke( $feedzy, 'example.com' ) );
+		$this->assertSame( '', $convert_host->invoke( $feedzy, '' ) );
+
+		// When neither path can convert the host it is returned unchanged.
+		$this->assertSame( $unconvertible, $convert_host->invoke( $feedzy, $unconvertible ) );
+	}
+
+	/**
+	 * The featured image cron must keep running when an internationalized URL is imported,
+	 * no matter whether the `intl` extension is installed.
+	 */
+	public function test_try_save_featured_image_with_internationalized_url() {
+		$feedzy    = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$reflector = new ReflectionClass( $feedzy );
+
+		$try_save_featured_image = $reflector->getMethod( 'try_save_featured_image' );
+		$try_save_featured_image->setAccessible( true );
+
+		$logged = array();
+		add_filter(
+			'themeisle_log_event',
+			function ( $product, $message, $type ) use ( &$logged ) {
+				$logged[] = array( $type, $message );
+			},
+			10,
+			5
+		);
+
+		$import_info = array();
+		$arguments   = array( 'https://bücher.example.com/path_to_image/ïmage.jpg', 0, 'Post Title', &$import_info, array() );
+		$response    = $try_save_featured_image->invokeArgs( $feedzy, $arguments );
+
+		// The image does not exist, so the download fails, but the URL itself must pass validation.
+		$this->assertFalse( $response );
+
+		foreach ( $logged as $entry ) {
+			$this->assertStringNotContainsString( 'Invalid image URL', $entry[1], 'Internationalized URL should not be rejected as invalid' );
+		}
+	}
 }

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -244,14 +244,15 @@ class Test_Image_Import extends WP_UnitTestCase {
 		$try_save_featured_image = $reflector->getMethod( 'try_save_featured_image' );
 		$try_save_featured_image->setAccessible( true );
 
-		$logged = array();
+		$requested_urls = array();
 		add_filter(
-			'themeisle_log_event',
-			function ( $product, $message, $type ) use ( &$logged ) {
-				$logged[] = array( $type, $message );
+			'pre_http_request',
+			function ( $preempt, $request_args, $url ) use ( &$requested_urls ) {
+ 				$requested_urls[] = $url;
+ 				return new WP_Error( 'test_download_failure', 'Expected test download failure.' );
 			},
 			10,
-			5
+			3
 		);
 
 		$import_info = array();
@@ -261,8 +262,6 @@ class Test_Image_Import extends WP_UnitTestCase {
 		// The image does not exist, so the download fails, but the URL itself must pass validation.
 		$this->assertFalse( $response );
 
-		foreach ( $logged as $entry ) {
-			$this->assertStringNotContainsString( 'Invalid image URL', $entry[1], 'Internationalized URL should not be rejected as invalid' );
-		}
+		$this->assertNotEmpty( $requested_urls, 'Internationalized URL should pass validation and reach the HTTP layer.' );
 	}
 }

--- a/tests/test-image-import.php
+++ b/tests/test-image-import.php
@@ -248,8 +248,8 @@ class Test_Image_Import extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $request_args, $url ) use ( &$requested_urls ) {
- 				$requested_urls[] = $url;
- 				return new WP_Error( 'test_download_failure', 'Expected test download failure.' );
+				$requested_urls[] = $url;
+				return new WP_Error( 'test_download_failure', 'Expected test download failure.' );
 			},
 			10,
 			3


### PR DESCRIPTION
This PR merges the latest changes from `development` into `master`.

### Linked issues
<!-- linked-issues:start -->
This release will close the following issues once merged:

- Closes #1302 — Featured-image cron import crashes when `idn_to_ascii()` is unavailable
- Closes #1305 — "Save Actions" fails for OpenAI featured-image actions with `clearPersistedData` error
<!-- linked-issues:end -->

### Public changelog
<!-- public-changelog:start -->
- Fixed an error when importing feed featured images on servers without the PHP intl extension.
- Fixed the "Save Actions" button not working for OpenAI featured-image actions.
<!-- public-changelog:end -->
