### PR TITLE
feat: migrate PA-API 5 to creator API

### DIFF
--- a/includes/views/amazon-product-advertising-view.php
+++ b/includes/views/amazon-product-advertising-view.php
@@ -51,29 +51,27 @@ $content = ! apply_filters( 'feedzy_is_license_of_type', false, 'business' ) ? _
 				</div>
 			</div>
 			<div class="fz-form-row">
-			<div class="fz-form-col-6">
-				<div class="fz-form-group">
-					<label class="form-label"><?php esc_html_e( 'Host:', 'feedzy-rss-feeds' ); ?></label>
-					<select class="form-control fz-select-control">
-						<option>webservices.amazon.com</option>
-					</select>
+				<div class="fz-form-col-6">
+					<div class="fz-form-group">
+						<label class="form-label"><?php esc_html_e( 'Marketplace', 'feedzy-rss-feeds' ); ?>:</label>
+						<div class="fz-input-group">
+							<div class="fz-input-group-left">
+								<select class="form-control fz-select-control">
+									<option>www.amazon.com</option>
+								</select>
+								<div class="help-text"><?php esc_html_e( 'API Status: Invalid | Last check: Never', 'feedzy-rss-feeds' ); ?></div>
+							</div>
+						</div>
+					</div>
 				</div>
-			</div>
-			<div class="fz-form-col-6">
-				<div class="fz-form-group">
-					<label class="form-label"><?php esc_html_e( 'Region:', 'feedzy-rss-feeds' ); ?></label>
-					<select class="form-control fz-select-control">
-						<option>us-east-1</option>
-					</select>
-				</div>
-			</div>
-		</div>
-			<div class="fz-form-group">
-				<label class="form-label"><?php esc_html_e( 'Partner Tag (store/tracking id):', 'feedzy-rss-feeds' ); ?></label>
-				<div class="fz-input-group">
-					<div class="fz-input-group-left">
-						<input type="text" class="form-control" name="amazon_partner_tag" placeholder="<?php echo esc_attr( __( 'Partner Tag (store/tracking id)', 'feedzy-rss-feeds' ) ); ?>"/>
-						<div class="help-text"><?php esc_html_e( 'API Status: Invalid | Last check: Never', 'feedzy-rss-feeds' ); ?></div>
+				<div class="fz-form-col-6">
+					<div class="fz-form-group">
+						<label class="form-label"><?php esc_html_e( 'Partner Tag (store/tracking id):', 'feedzy-rss-feeds' ); ?></label>
+						<div class="fz-input-group">
+							<div class="fz-input-group-left">
+								<input type="text" class="form-control" name="amazon_partner_tag" placeholder="<?php echo esc_attr( __( 'Partner Tag (store/tracking id)', 'feedzy-rss-feeds' ) ); ?>"/>
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/includes/views/amazon-product-advertising-view.php
+++ b/includes/views/amazon-product-advertising-view.php
@@ -39,24 +39,24 @@ $content = ! apply_filters( 'feedzy_is_license_of_type', false, 'business' ) ? _
 			<div class="fz-form-row">
 				<div class="fz-form-col-6">
 					<div class="fz-form-group">
-						<label class="form-label"><?php esc_html_e( 'Access Key:', 'feedzy-rss-feeds' ); ?></label>
-						<input type="password" class="form-control" placeholder="<?php echo esc_attr( __( 'Access Key', 'feedzy-rss-feeds' ) ); ?>"/>
+						<label class="form-label"><?php esc_html_e( 'Client ID', 'feedzy-rss-feeds' ); ?>:</label>
+						<input type="password" class="form-control" placeholder="<?php echo esc_attr( __( 'Client ID', 'feedzy-rss-feeds' ) ); ?>"/>
 					</div>
 				</div>
 				<div class="fz-form-col-6">
 					<div class="fz-form-group">
-						<label class="form-label"><?php esc_html_e( 'Secret key:', 'feedzy-rss-feeds' ); ?></label>
-						<input type="password" class="form-control" placeholder="<?php echo esc_attr( __( 'Secret key', 'feedzy-rss-feeds' ) ); ?>"/>
+						<label class="form-label"><?php esc_html_e( 'Client Secret', 'feedzy-rss-feeds' ); ?>:</label>
+						<input type="password" class="form-control" placeholder="<?php echo esc_attr( __( 'Client Secret', 'feedzy-rss-feeds' ) ); ?>"/>
 					</div>
 				</div>
 			</div>
 			<div class="fz-form-row">
 				<div class="fz-form-col-6">
 					<div class="fz-form-group">
-						<label class="form-label"><?php esc_html_e( 'Marketplace', 'feedzy-rss-feeds' ); ?>:</label>
+						<label class="form-label" for="amazon_marketplace"><?php esc_html_e( 'Marketplace', 'feedzy-rss-feeds' ); ?>:</label>
 						<div class="fz-input-group">
 							<div class="fz-input-group-left">
-								<select class="form-control fz-select-control">
+								<select id="amazon_marketplace" class="form-control fz-select-control">
 									<option>www.amazon.com</option>
 								</select>
 								<div class="help-text"><?php esc_html_e( 'API Status: Invalid | Last check: Never', 'feedzy-rss-feeds' ); ?></div>


### PR DESCRIPTION
### Summary
Updated Amazon Product Advertising form to migrate PA-API to the Creator API.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR(Here, I only updated the form view. The test cases have been added in the Pro plugin PR.)
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/1012