### PR TITLE
Fix multi-feed lazy shortcode nonce collapsing to "Array"

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -471,7 +471,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 
 			// Add nonce based on feed url.
-			$attributes .= 'data-nonce="' . esc_attr( wp_create_nonce( $feed_url ) ) . '"';
+			$attributes .= 'data-nonce="' . esc_attr( wp_create_nonce( $this->feed_nonce_action( $feed_url ) ) ) . '"';
 			$attributes .= 'data-error_msg="' . esc_attr( apply_filters( 'feedzy_lazyload_error_msg', __( 'An error occurred while fetching the feed.', 'feedzy-rss-feeds' ), $feed_url ) ) . '"';
 
 			$class = array_filter( apply_filters( 'feedzy_add_classes_block', array( $sc['classname'], 'feedzy-' . md5( is_array( $feed_url ) ? implode( ',', $feed_url ) : $feed_url ) ), $sc, null, $feed_url ) );
@@ -574,7 +574,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		$feed_url = $this->normalize_urls( $sc['feeds'] );
 		$nonce    = isset( $atts['nonce'] ) ? $atts['nonce'] : '';
 
-		if ( ! wp_verify_nonce( $nonce, $feed_url ) ) {
+		if ( ! wp_verify_nonce( $nonce, $this->feed_nonce_action( $feed_url ) ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'feedzy-rss-feeds' ) ) );
 		}
 
@@ -736,6 +736,20 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		return $feed_url;
+	}
+
+	/**
+	 * Derives a deterministic nonce action string from a normalized feed URL.
+	 * normalize_urls() returns an array for multi-feed shortcodes, and PHP's
+	 * array-to-string coercion collapses any array to "Array" if passed
+	 * straight into wp_create_nonce()/wp_verify_nonce(), making every
+	 * multi-feed shortcode share the same nonce action.
+	 *
+	 * @param   string|array<string> $feed_url The normalized feed url(s).
+	 * @return  string
+	 */
+	private function feed_nonce_action( $feed_url ) {
+		return is_array( $feed_url ) ? implode( ',', $feed_url ) : $feed_url;
 	}
 
 	/**
@@ -1651,11 +1665,11 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 	 */
 	private function get_feed_title_filter( $feed, $sc, $feed_url ) {
 		return array(
-			'rss_url'               => $feed->get_permalink(),
+			'rss_url'               => ! empty( $feed->get_permalink() ) ? $feed->get_permalink() : '',
 			'rss_title_class'       => 'rss_title',
 			'rss_title'             => html_entity_decode( ! empty( $feed->get_title() ) ? $feed->get_title() : '' ),
 			'rss_description_class' => 'rss_description',
-			'rss_description'       => $feed->get_description(),
+			'rss_description'       => ! empty( $feed->get_description() ) ? $feed->get_description() : '',
 			'rss_classes'           => array( $sc['classname'], 'feedzy-' . md5( is_array( $feed_url ) ? implode( ', ', $feed_url ) : $feed_url ) ),
 		);
 	}

--- a/tests/test-admin-abstract-helpers.php
+++ b/tests/test-admin-abstract-helpers.php
@@ -402,4 +402,74 @@ class Test_Admin_Abstract_Helpers extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'classname', $sc );
 		$this->assertEquals( 'my-class', $sc['classname'] );
 	}
+
+	/**
+	 * Invoke the private feed_nonce_action() method through reflection.
+	 *
+	 * @param string|array $feed_url The normalized feed url(s).
+	 *
+	 * @return string
+	 */
+	private function feed_nonce_action( $feed_url ) {
+		$method = new ReflectionMethod( 'Feedzy_Rss_Feeds_Admin_Abstract', 'feed_nonce_action' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->feedzy_abstract, $feed_url );
+	}
+
+	/**
+	 * Test feed_nonce_action does not collapse multi-feed arrays to "Array".
+	 *
+	 * @access public
+	 */
+	public function test_feed_nonce_action_multi_feed_does_not_collapse_to_array() {
+		$action = $this->feed_nonce_action( array( 'https://example.com/feed1', 'https://example.com/feed2' ) );
+
+		$this->assertNotEquals( 'Array', $action );
+	}
+
+	/**
+	 * Test feed_nonce_action produces distinct actions for distinct feed sets,
+	 * so a nonce for one multi-feed shortcode does not validate for another.
+	 *
+	 * @access public
+	 */
+	public function test_feed_nonce_action_differs_between_feed_sets() {
+		$action_a = $this->feed_nonce_action( array( 'https://example.com/a1', 'https://example.com/a2' ) );
+		$action_b = $this->feed_nonce_action( array( 'https://example.com/b1', 'https://example.com/b2' ) );
+
+		$this->assertNotEquals( $action_a, $action_b );
+	}
+
+	/**
+	 * Test feed_nonce_action passes single-feed (scalar) urls through unchanged.
+	 *
+	 * @access public
+	 */
+	public function test_feed_nonce_action_single_feed_returns_scalar_unchanged() {
+		$this->assertEquals( 'https://example.com/feed', $this->feed_nonce_action( 'https://example.com/feed' ) );
+	}
+
+	/**
+	 * Test get_feed_title_filter falls back to an empty string for rss_url and
+	 * rss_description when the feed provides none, instead of null.
+	 *
+	 * @access public
+	 */
+	public function test_get_feed_title_filter_null_safe_url_and_description() {
+		$method = new ReflectionMethod( 'Feedzy_Rss_Feeds_Admin_Abstract', 'get_feed_title_filter' );
+		$method->setAccessible( true );
+
+		$feed = $this->getMockBuilder( 'stdClass' )
+			->addMethods( array( 'get_permalink', 'get_description', 'get_title' ) )
+			->getMock();
+		$feed->method( 'get_permalink' )->willReturn( null );
+		$feed->method( 'get_description' )->willReturn( null );
+		$feed->method( 'get_title' )->willReturn( null );
+
+		$result = $method->invoke( $this->feedzy_abstract, $feed, array( 'classname' => '' ), 'https://example.com/feed' );
+
+		$this->assertSame( '', $result['rss_url'] );
+		$this->assertSame( '', $result['rss_description'] );
+	}
 }


### PR DESCRIPTION
### Summary

`feedzy_rss()` and `feedzy_lazy_load()` both passed the normalized feed url array directly into `wp_create_nonce()` / `wp_verify_nonce()`. PHP's array-to-string coercion collapses any array into the literal string `"Array"`, so every multi-feed lazy shortcode (`[feedzy-rss feeds="url1,url2" lazy="yes"]`) shared the exact same nonce action instead of a feed-set-specific one — weakening request separation between different multi-feed shortcodes.

Adds a shared `feed_nonce_action()` helper, used symmetrically at both nonce generation (`feedzy_rss()`) and validation (`feedzy_lazy_load()`), so multi-feed nonces are now derived from the actual feed set.

While testing this, also found and fixed a related null-safety gap: `get_feed_title_filter()` passed `rss_url`/`rss_description` straight from `$feed->get_permalink()`/`get_description()` with no fallback (unlike `rss_title`, right next to it, which already had one). When a feed provides no link/description, this triggered `ltrim()`/`preg_replace()` deprecation notices downstream in `esc_url()`/`wp_kses_post()`. Added the same `!empty(...) ? ... : ''` guard already used for `rss_title`.

### Will affect visual aspect of the product
NO

### Test instructions

- Render two `[feedzy-rss feeds="..." lazy="yes"]` shortcodes with different multi-feed URL sets on the same page.
- Before this PR: both shortcodes' `data-nonce` attribute are identical, and `WP_DEBUG` logs `Array to string conversion` warnings.
- After this PR: the two `data-nonce` values differ, and submitting one shortcode's nonce with another's feed attributes is rejected by `feedzy_lazy_load()`.
- Added unit tests in `tests/test-admin-abstract-helpers.php` covering `feed_nonce_action()` and the `get_feed_title_filter()` null-safety fix.

## Check before Pull Request is ready:

* [x] I have written a test and included it in this PR
* [ ] I have run all tests and they pass (full WP integration test suite needs `svn`/a WP test DB not available in the sandbox this was prepared in — PHPCS and PHPStan both pass locally; CI will run the full PHPUnit suite)
* [x] The code passes when running the PHP CodeSniffer
* [x] Code meets WordPress Coding Standards for PHP, HTML, CSS and JS
* [x] Security and Sanitization requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR

Closes #1318.
Also fixes Codeinwp/feedzy-rss-feeds-pro#1016 (same root cause, reported separately against the Pro repo — the buggy code lives entirely in this free plugin).
