### PR TITLE
Fixed TypeError when url param is a string

### DIFF
--- a/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
@@ -398,6 +398,9 @@ class Feedzy_Rss_Feeds_Gutenberg_Block {
 	 * @return string|array The sanitized feeds.
 	 */
 	public function feedzy_sanitize_feeds( $input ) {
+		if ( ! is_array( $input ) ) {
+			return wp_http_validate_url( $input ) ? esc_url_raw( $input ) : '';
+		}
 		if ( count( $input ) === 1 ) {
 			$feed = wp_http_validate_url( $input[0] );
 			return $feed;

--- a/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
+++ b/includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php
@@ -392,9 +392,9 @@ class Feedzy_Rss_Feeds_Gutenberg_Block {
 
 	/**
 	 * Sanitize Rest API Return
-	 * 
-	 * @param array $input The feeds.
-	 * 
+	 *
+	 * @param array|string $input The feeds, either as an array of urls or a single url string.
+	 *
 	 * @return string|array The sanitized feeds.
 	 */
 	public function feedzy_sanitize_feeds( $input ) {

--- a/tests/test-gutenberg-block-sanitize.php
+++ b/tests/test-gutenberg-block-sanitize.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tests for Feedzy_Rss_Feeds_Gutenberg_Block::feedzy_sanitize_feeds().
+ *
+ * @since      5.2.9
+ *
+ * @package    feedzy-rss-feeds
+ */
+class Test_Gutenberg_Block_Sanitize extends WP_UnitTestCase {
+
+	/**
+	 * Instance of the class being tested.
+	 *
+	 * @var Feedzy_Rss_Feeds_Gutenberg_Block
+	 */
+	private $block;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @access public
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->block = Feedzy_Rss_Feeds_Gutenberg_Block::get_instance();
+	}
+
+	/**
+	 * A scalar string url should be validated/escaped directly instead of
+	 * triggering a TypeError from count().
+	 *
+	 * @access public
+	 */
+	public function test_sanitize_feeds_with_string_input() {
+		$result = $this->block->feedzy_sanitize_feeds( 'https://example.com/feed' );
+
+		$this->assertEquals( 'https://example.com/feed', $result );
+	}
+
+	/**
+	 * An invalid scalar string url should not validate and should return an empty string.
+	 *
+	 * @access public
+	 */
+	public function test_sanitize_feeds_with_invalid_string_input() {
+		$result = $this->block->feedzy_sanitize_feeds( 'not-a-url' );
+
+		$this->assertEquals( '', $result );
+	}
+
+	/**
+	 * A single-item array should still return a single validated url string.
+	 *
+	 * @access public
+	 */
+	public function test_sanitize_feeds_with_single_item_array() {
+		$result = $this->block->feedzy_sanitize_feeds( array( 'https://example.com/feed' ) );
+
+		$this->assertEquals( 'https://example.com/feed', $result );
+	}
+
+	/**
+	 * A multi-item array should return an array of validated urls.
+	 *
+	 * @access public
+	 */
+	public function test_sanitize_feeds_with_multiple_item_array() {
+		$result = $this->block->feedzy_sanitize_feeds(
+			array( 'https://example.com/feed', 'https://example.org/feed', 'not-a-url' )
+		);
+
+		$this->assertEquals( array( 'https://example.com/feed', 'https://example.org/feed' ), $result );
+	}
+}

--- a/tests/test-gutenberg-block-sanitize.php
+++ b/tests/test-gutenberg-block-sanitize.php
@@ -33,9 +33,9 @@ class Test_Gutenberg_Block_Sanitize extends WP_UnitTestCase {
 	 * @access public
 	 */
 	public function test_sanitize_feeds_with_string_input() {
-		$result = $this->block->feedzy_sanitize_feeds( 'https://example.com/feed' );
+		$result = $this->block->feedzy_sanitize_feeds( 'https://example.org/feed' );
 
-		$this->assertEquals( 'https://example.com/feed', $result );
+		$this->assertEquals( 'https://example.org/feed', $result );
 	}
 
 	/**
@@ -55,9 +55,9 @@ class Test_Gutenberg_Block_Sanitize extends WP_UnitTestCase {
 	 * @access public
 	 */
 	public function test_sanitize_feeds_with_single_item_array() {
-		$result = $this->block->feedzy_sanitize_feeds( array( 'https://example.com/feed' ) );
+		$result = $this->block->feedzy_sanitize_feeds( array( 'https://example.org/feed' ) );
 
-		$this->assertEquals( 'https://example.com/feed', $result );
+		$this->assertEquals( 'https://example.org/feed', $result );
 	}
 
 	/**
@@ -67,9 +67,9 @@ class Test_Gutenberg_Block_Sanitize extends WP_UnitTestCase {
 	 */
 	public function test_sanitize_feeds_with_multiple_item_array() {
 		$result = $this->block->feedzy_sanitize_feeds(
-			array( 'https://example.com/feed', 'https://example.org/feed', 'not-a-url' )
+			array( 'https://example.org/feed1', 'https://example.org/feed2', 'not-a-url' )
 		);
 
-		$this->assertEquals( array( 'https://example.com/feed', 'https://example.org/feed' ), $result );
+		$this->assertEquals( array( 'https://example.org/feed1', 'https://example.org/feed2' ), $result );
 	}
 }


### PR DESCRIPTION
### Summary
- Fixes a fatal `TypeError` in `feedzy_sanitize_feeds()` (includes/gutenberg/feedzy-rss-feeds-gutenberg-block.php) when the `/wp-json/feedzy/v1/feed` REST endpoint receives url as a scalar string instead of an array, by validating/escaping scalar input directly before the count() call.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #1316
