### PR TITLE
Guard non-array shortcode attribute filter results

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -703,7 +703,11 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 			$sc['classname'] = $sc['className'];
 			unset( $sc['className'] );
 		}
-		$sc = array_merge( $sc, apply_filters( 'feedzy_get_short_code_attributes_filter', $atts ) );
+		$filtered_atts = apply_filters( 'feedzy_get_short_code_attributes_filter', $atts );
+		if ( ! is_array( $filtered_atts ) ) {
+			$filtered_atts = array();
+		}
+		$sc = array_merge( $sc, $filtered_atts );
 
 		return $sc;
 	}

--- a/tests/test-admin-abstract-helpers.php
+++ b/tests/test-admin-abstract-helpers.php
@@ -402,4 +402,20 @@ class Test_Admin_Abstract_Helpers extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'classname', $sc );
 		$this->assertEquals( 'my-class', $sc['classname'] );
 	}
+
+	/**
+	 * Invalid filter return values should not crash shortcode attribute preparation.
+	 *
+	 * @access public
+	 */
+	public function test_get_short_code_attributes_ignores_null_filter_result() {
+		add_filter( 'feedzy_get_short_code_attributes_filter', '__return_null' );
+
+		$sc = $this->feedzy_abstract->get_short_code_attributes( array() );
+
+		remove_filter( 'feedzy_get_short_code_attributes_filter', '__return_null' );
+
+		$this->assertIsArray( $sc );
+		$this->assertEquals( '5', $sc['max'] );
+	}
 }


### PR DESCRIPTION
## Summary

- normalize invalid shortcode attribute filter results to an empty array
- prevent array_merge from receiving null or another unsupported value
- cover the null-filter path with a regression test

## Testing

- focused PHPUnit regression: 2 assertions
- PHPCS on the changed files

Closes #1324