### PR TITLE
Preserve validation response shape for empty category sources

### DIFF
--- a/includes/admin/feedzy-rss-feeds-admin.php
+++ b/includes/admin/feedzy-rss-feeds-admin.php
@@ -2016,15 +2016,16 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 	/**
 	 * Validates the source (category or URL(s)) and returns only the ones that were found to be valid.
 	 *
-	 * @param string $src                   Source string.
-	 * @param int    $post_id               Post ID.
-	 * @param bool   $add_pseudo_transient  Add pseudo transient.
-	 * @param bool   $return_valid          Return valid.
+	 * @param string    $src                   Source string.
+	 * @param int       $post_id               Post ID.
+	 * @param bool      $add_pseudo_transient  Add pseudo transient.
+	 * @param bool|null $return_valid       Return valid, or both result sets when null.
 	 * @return array
 	 */
 	public function check_source_validity( $src, $post_id, $add_pseudo_transient, $return_valid ) {
-		$urls_in   = $src;
-		$post_type = get_post_type( $post_id );
+		$urls_in     = $src;
+		$post_type   = get_post_type( $post_id );
+		$return_both = is_null( $return_valid );
 		if ( 'feedzy_imports' === $post_type && false === strpos( $src, 'http' ) && false === strpos( $src, 'https' ) ) {
 			// category.
 			$category = get_page_by_path( $src, OBJECT, 'feedzy_categories' );
@@ -2037,7 +2038,12 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 		// even without clicking the publish button,
 		// thereby sending empty urls.
 		if ( empty( $urls_in ) ) {
-			return array();
+			return $return_both
+				? array(
+					'valid'   => array(),
+					'invalid' => array(),
+				)
+				: array();
 		}
 
 		$urls = $this->normalize_urls( $urls_in );
@@ -2062,7 +2068,7 @@ class Feedzy_Rss_Feeds_Admin extends Feedzy_Rss_Feeds_Admin_Abstract {
 			}
 		}
 
-		if ( is_null( $return_valid ) ) {
+		if ( $return_both ) {
 			return array(
 				'valid'   => $valid,
 				'invalid' => $invalid,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -447,7 +447,7 @@ parameters:
 
 		-
 			message: "#^Call to function is_null\\(\\) with bool will always evaluate to false\\.$#"
-			count: 2
+			count: 1
 			path: includes/admin/feedzy-rss-feeds-admin.php
 
 		-
@@ -692,11 +692,6 @@ parameters:
 
 		-
 			message: "#^Method Feedzy_Rss_Feeds_Admin\\:\\:setup_wizard_subscribe_process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: includes/admin/feedzy-rss-feeds-admin.php
-
-		-
-			message: "#^Parameter \\#4 \\$return_valid of method Feedzy_Rss_Feeds_Admin\\:\\:check_source_validity\\(\\) expects bool, null given\\.$#"
 			count: 1
 			path: includes/admin/feedzy-rss-feeds-admin.php
 

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -11,6 +11,21 @@
  */
 class Test_Feedzy extends WP_UnitTestCase {
 	/**
+	 * Keeps the keyed validation response shape when a category has no feeds.
+	 */
+	public function test_empty_category_source_returns_keyed_validation_result() {
+		$admin = Feedzy_Rss_Feeds::instance()->get_admin();
+
+		$this->assertSame(
+			array(
+				'valid'   => array(),
+				'invalid' => array(),
+			),
+			$admin->check_source_validity( '', 0, false, null )
+		);
+	}
+
+	/**
 	 * Test method to check Create | Update and Feed from Slug
 	 *
 	 * @since   3.0.12


### PR DESCRIPTION
## Summary

- return keyed valid and invalid arrays for empty clean-validation requests
- preserve the existing flat empty-array response for the boolean modes
- cover the empty keyed response with a regression test

## Testing

- focused PHPUnit regression: 1 assertion
- PHPCS on the changed files

Closes #1314