### PR TITLE
Use safe filesystem permission defaults for logger setup

### DIFF
--- a/includes/admin/feedzy-rss-feeds-log.php
+++ b/includes/admin/feedzy-rss-feeds-log.php
@@ -250,14 +250,27 @@ class Feedzy_Rss_Feeds_Log {
 	private function setup_log_directory() {
 		$upload_dir = wp_upload_dir();
 		$log_dir    = $upload_dir['basedir'] . '/feedzy-logs';
+		$dir_mode   = $this->get_filesystem_permission( 'FS_CHMOD_DIR', 0755 );
+		$file_mode  = $this->get_filesystem_permission( 'FS_CHMOD_FILE', 0644 );
 
 		if ( ! $this->filesystem->exists( $log_dir ) ) {
-			$this->filesystem->mkdir( $log_dir, FS_CHMOD_DIR );
-			$this->filesystem->put_contents( $log_dir . '/.htaccess', "Deny from all\n", FS_CHMOD_FILE );
-			$this->filesystem->put_contents( $log_dir . '/index.php', "<?php // Silence is golden\n", FS_CHMOD_FILE );
+			$this->filesystem->mkdir( $log_dir, $dir_mode );
+			$this->filesystem->put_contents( $log_dir . '/.htaccess', "Deny from all\n", $file_mode );
+			$this->filesystem->put_contents( $log_dir . '/index.php', "<?php // Silence is golden\n", $file_mode );
 		}
 
 		$this->filepath = $this->get_log_file_path();
+	}
+
+	/**
+	 * Resolve a WordPress filesystem permission constant with a safe default.
+	 *
+	 * @param string $constant_name Permission constant name.
+	 * @param int    $fallback      Permission used when the constant is unavailable.
+	 * @return int
+	 */
+	private function get_filesystem_permission( $constant_name, $fallback ) {
+		return defined( $constant_name ) ? (int) constant( $constant_name ) : $fallback;
 	}
 
 	/**

--- a/tests/test-log.php
+++ b/tests/test-log.php
@@ -124,6 +124,16 @@ class Test_Logger extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Logger setup must have a permission value before WordPress defines its constants.
+	 */
+	public function test_filesystem_permission_falls_back_for_undefined_constant() {
+		$method = new ReflectionMethod( Feedzy_Rss_Feeds_Log::class, 'get_filesystem_permission' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 0755, $method->invoke( $this->logger, 'FEEDZY_TEST_UNDEFINED_CHMOD', 0755 ) );
+	}
+
+	/**
 	 * Test log level constants.
 	 */
 	public function test_log_level_constants() {


### PR DESCRIPTION
## Summary

- resolve WordPress filesystem permission constants before creating log files
- fall back to 0755 for directories and 0644 for files when constants are unavailable
- cover the undefined-constant path with a focused regression

## Testing

- focused PHPUnit regression: 1 assertion
- PHPCS on the changed files

Closes #1320