### PR TITLE
Handle feed errors before accessing import results

### DIFF
--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -1933,15 +1933,8 @@ class Feedzy_Rss_Feeds_Import {
 		$import_errors = array();
 
 		// the array that captures additional information about the import.
-		$import_info   = array();
-		$results       = $this->get_job_feed( $options, $import_content, true );
-		$language_code = $results['feed']->get_language();
-		
-		$xml_results = '';
-		if ( str_contains( $import_content, '_full_content' ) ) {
-			$xml_results = $this->get_job_feed( $options, '[#item_content]', true );
-		}
-		
+		$import_info = array();
+		$results     = $this->get_job_feed( $options, $import_content, true );
 		if ( is_wp_error( $results ) ) {
 			// BUG: If $results is error, the import run details will not show the results even if the errors are set.
 			Feedzy_Rss_Feeds_Log::error(
@@ -1965,6 +1958,13 @@ class Feedzy_Rss_Feeds_Import {
 			update_post_meta( $job->ID, 'imported_items_count', 0 );
 
 			return 0;
+		}
+
+		$language_code = $results['feed']->get_language();
+
+		$xml_results = '';
+		if ( str_contains( $import_content, '_full_content' ) ) {
+			$xml_results = $this->get_job_feed( $options, '[#item_content]', true );
 		}
 
 		$result = $results['items'];

--- a/tests/test-import.php
+++ b/tests/test-import.php
@@ -24,6 +24,34 @@ class Test_Feedzy_Import extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Stops a failed feed URL filter before the import tries to read feed data.
+	 */
+	public function test_import_stops_when_feed_url_filter_returns_error() {
+		$owner_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$import_id = $this->create_import( $owner_id );
+
+		update_post_meta( $import_id, 'source', 'https://example.com/feed' );
+		update_post_meta( $import_id, 'import_post_title', '[#item_title]' );
+		update_post_meta( $import_id, 'import_post_content', '[#item_content]' );
+
+		$feed_error = function () {
+			return new WP_Error( 'feedzy_test_error', 'The feed is unavailable.' );
+		};
+		add_filter( 'feedzy_import_feed_url', $feed_error );
+
+		$import = new Feedzy_Rss_Feeds_Import( 'feedzy-rss-feeds', '1.2.0' );
+		$method = new ReflectionMethod( $import, 'run_job_logic' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $import, get_post( $import_id ), 1 );
+
+		remove_filter( 'feedzy_import_feed_url', $feed_error );
+
+		$this->assertSame( 0, $result );
+		$this->assertSame( '0', get_post_meta( $import_id, 'imported_items_count', true ) );
+		$this->assertNotEmpty( get_post_meta( $import_id, 'import_errors', true ) );
+	}
+
+	/**
 	 * Test method to check Feedzy Imports
 	 *
 	 * @requires PHP 5.4


### PR DESCRIPTION
## Summary

- handle WP_Error results immediately after fetching the feed
- preserve the existing error log and import metadata updates
- avoid reading feed language or item data from an error object

## Testing

- focused PHPUnit regression: 3 assertions
- PHPCS on the changed files

Closes #1319