### PR TITLE
Improved compatibility with SimplePie

### DIFF
--- a/includes/abstract/feedzy-rss-feeds-admin-abstract.php
+++ b/includes/abstract/feedzy-rss-feeds-admin-abstract.php
@@ -931,7 +931,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
 			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-			$set_server_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) . \SimplePie\Misc::get_default_useragent() );
+			$set_server_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) . $this->get_simplepie_useragent() );
 			$feed->set_useragent( apply_filters( 'http_headers_useragent', $set_server_agent, $feed_url ) );
 		}
 
@@ -1000,7 +1000,7 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 
 			if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
 				// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-				$set_server_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) . \SimplePie\Misc::get_default_useragent() );
+				$set_server_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) . $this->get_simplepie_useragent() );
 				$feed_instance->set_useragent( apply_filters( 'http_headers_useragent', $set_server_agent, $url ) );
 			}
 
@@ -1177,7 +1177,8 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 		require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 
-		$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File', true );
+		$file_handler = class_exists( '\SimplePie\File' ) ? 'SimplePie\File' : 'File';
+		$feed->get_registry()->register( $file_handler, 'WP_SimplePie_File', true );
 		$default_agent = $this->get_default_user_agent( $feed_url );
 		$feed->set_useragent( apply_filters( 'http_headers_useragent', $default_agent, is_array( $feed_url ) ? reset( $feed_url ) : $feed_url ) );
 
@@ -1327,7 +1328,29 @@ abstract class Feedzy_Rss_Feeds_Admin_Abstract {
 		}
 
 		// Use SimplePie's default user agent as fallback.
-		return \SimplePie\Misc::get_default_useragent();
+		return $this->get_simplepie_useragent();
+	}
+
+	/**
+	 * Get SimplePie's own default user agent, whichever SimplePie WordPress bundles.
+	 *
+	 * WordPress ships namespaced SimplePie 1.8 from 6.7 onwards. Earlier versions
+	 * bundle SimplePie 1.5, where the agent is only available as a constant.
+	 *
+	 * @access  private
+	 *
+	 * @return string SimplePie default user agent.
+	 */
+	private function get_simplepie_useragent() {
+		if ( class_exists( '\SimplePie\Misc' ) ) {
+			return \SimplePie\Misc::get_default_useragent();
+		}
+
+		if ( defined( 'SIMPLEPIE_USERAGENT' ) ) {
+			return (string) constant( 'SIMPLEPIE_USERAGENT' );
+		}
+
+		return FEEDZY_USER_AGENT;
 	}
 
 	/**

--- a/includes/admin/feedzy-rss-feeds-import.php
+++ b/includes/admin/feedzy-rss-feeds-import.php
@@ -272,10 +272,12 @@ class Feedzy_Rss_Feeds_Import {
 			return $item_array;
 		}
 
-		$tags = $item->get_item_tags( \SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'group' );
+		$mediarss_ns = class_exists( '\SimplePie\SimplePie' ) ? \SimplePie\SimplePie::NAMESPACE_MEDIARSS : (string) constant( 'SIMPLEPIE_NAMESPACE_MEDIARSS' );
+
+		$tags = $item->get_item_tags( $mediarss_ns, 'group' );
 		$desc = '';
 		if ( $tags ) {
-			$desc_tag = $tags[0]['child'][ \SimplePie\SimplePie::NAMESPACE_MEDIARSS ]['description'];
+			$desc_tag = $tags[0]['child'][ $mediarss_ns ]['description'];
 			if ( $desc_tag ) {
 				$desc = $desc_tag[0]['data'];
 			}

--- a/tests/test-admin-abstract-helpers.php
+++ b/tests/test-admin-abstract-helpers.php
@@ -488,4 +488,76 @@ class Test_Admin_Abstract_Helpers extends WP_UnitTestCase {
 		$this->assertSame( '', $result['rss_description'] );
 		$this->assertSame( '', $result['rss_description'] );
 	}
+
+	/**
+	 * Invoke a private method of the abstract class through reflection.
+	 *
+	 * @param string $name Method name.
+	 * @param array  $args Arguments.
+	 *
+	 * @return mixed
+	 */
+	private function invoke_private( $name, array $args = array() ) {
+		$method = new ReflectionMethod( 'Feedzy_Rss_Feeds_Admin_Abstract', $name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $this->feedzy_abstract, $args );
+	}
+
+	/**
+	 * Load WordPress' SimplePie, the way create_simplepie_instance() does before
+	 * the user agent is resolved.
+	 *
+	 * @return void
+	 */
+	private function load_simplepie() {
+		if ( ! class_exists( 'SimplePie' ) ) {
+			require_once ABSPATH . WPINC . '/class-simplepie.php';
+		}
+	}
+
+	/**
+	 * Test get_default_user_agent keeps the browser agent for Medium sources,
+	 * for a single url and for an array of urls.
+	 *
+	 * @access public
+	 */
+	public function test_get_default_user_agent_medium_source_uses_browser_agent() {
+		$this->assertSame(
+			FEEDZY_USER_AGENT,
+			$this->invoke_private( 'get_default_user_agent', array( 'https://medium.com/feed/@someone' ) )
+		);
+
+		$this->assertSame(
+			FEEDZY_USER_AGENT,
+			$this->invoke_private(
+				'get_default_user_agent',
+				array( array( 'https://example.com/feed', 'https://medium.com/feed/@someone' ) )
+			)
+		);
+	}
+
+	/**
+	 * Test get_default_user_agent falls back to SimplePie's own agent for
+	 * non-Medium sources, for a single url and for an array of urls.
+	 *
+	 * @access public
+	 */
+	public function test_get_default_user_agent_non_medium_uses_simplepie_agent() {
+		$this->load_simplepie();
+
+		$agent = $this->invoke_private( 'get_default_user_agent', array( 'https://example.com/feed' ) );
+
+		$this->assertIsString( $agent );
+		$this->assertNotEmpty( $agent );
+		$this->assertNotSame( FEEDZY_USER_AGENT, $agent );
+
+		$this->assertSame(
+			$agent,
+			$this->invoke_private(
+				'get_default_user_agent',
+				array( array( 'https://example.com/feed', 'https://example.org/feed' ) )
+			)
+		);
+	}
 }


### PR DESCRIPTION
### Summary
Improved compatibility with the SimplePie library, ensuring the plugin works smoothly with both the newer namespaced `SimplePie` (bundled with WordPress 6.7+) and older versions.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/feedzy-rss-feeds/issues/1308